### PR TITLE
extension helpers: fix warning during regex compilation

### DIFF
--- a/xivo/tests/test_xivo_helpers.py
+++ b/xivo/tests/test_xivo_helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2013-2014 Avencall
+# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -31,3 +31,18 @@ class TestXivoHelpers(unittest.TestCase):
         result = xivo_helpers.fkey_extension(self.PREFIX, arguments)
 
         self.assertEqual(result, '*735123***225')
+
+
+class TestPositionOfAsteriskPatternChar(unittest.TestCase):
+    def test_position_of_asterisk_pattern_char(self):
+        samples = [
+            ('_418[1-5]XZ123', 4),
+            ('418-123-5599', None),
+            ('_NXXXXXXXXXX', 1),
+            ('NXXXXXXXXXX', 0),
+            ('_1XXXXXXXXXX', 2),
+        ]
+
+        for pattern, expected in samples:
+            result = xivo_helpers.position_of_asterisk_pattern_char(pattern)
+            self.assertEqual(result, expected)

--- a/xivo/xivo_helpers.py
+++ b/xivo/xivo_helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2008-2015 Avencall
+# Copyright 2008-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -9,7 +9,7 @@ import logging
 log = logging.getLogger("xivo.xivo_helpers")
 
 
-find_asterisk_pattern_char = re.compile('[[NXZ!.]').search
+find_asterisk_pattern_char = re.compile(r'[\[NXZ!.]').search
 
 
 def position_of_asterisk_pattern_char(ast_pattern):


### PR DESCRIPTION
the opening square bracket in the match group causes a warning.

/usr/lib/python3/dist-packages/xivo/xivo_helpers.py:12: FutureWarning: Possible nested set at position 1
  find_asterisk_pattern_char = re.compile('[[NXZ!.]').search