### PR TITLE
Allow to load config from consul

### DIFF
--- a/integration_tests/Dockerfile-config-from-consul
+++ b/integration_tests/Dockerfile-config-from-consul
@@ -1,0 +1,10 @@
+FROM python:3.7-buster
+
+COPY integration_tests/assets/bin /usr/local/bin
+COPY integration_tests/assets/etc /etc
+COPY . /tmp/xivo
+
+RUN cd /tmp/xivo && pip install -r requirements.txt
+RUN cd /tmp/xivo && python setup.py install
+
+CMD ["config-from-consul.py"]

--- a/integration_tests/Dockerfile-myservice
+++ b/integration_tests/Dockerfile-myservice
@@ -3,12 +3,7 @@ FROM python:2.7.16-buster
 COPY integration_tests/assets/bin /usr/local/bin
 COPY . /tmp/xivo
 
-RUN pip install \
-    kombu \
-    flask \
-    https://github.com/wazo-platform/xivo-bus/archive/master.zip \
-    python-consul==0.7.1 \
-    netifaces
+RUN cd /tmp/xivo && pip install -r requirements.txt kombu
 
 RUN cd /tmp/xivo && python setup.py install
 

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -6,7 +6,7 @@ egg-info:
 myservice:
 	docker build -t myservice -f Dockerfile-myservice ..
 
-test-setup: myservice thread-exception egg-info
+test-setup: myservice thread-exception config-from-consul egg-info
 	docker pull consul:1.0.7
 	docker pull rabbitmq
 	docker pull wazopbx/wait

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,4 +1,4 @@
-.PHONY: egg-info test-setup test myservice thread-exception
+.PHONY: egg-info test-setup test myservice thread-exception config-from-consul
 
 egg-info:
 	cd .. && python setup.py egg_info
@@ -7,7 +7,7 @@ myservice:
 	docker build -t myservice -f Dockerfile-myservice ..
 
 test-setup: myservice thread-exception egg-info
-	docker pull progrium/consul
+	docker pull consul
 	docker pull rabbitmq
 	docker pull wazopbx/wait
 	docker pull python:3.7-slim-buster
@@ -17,3 +17,6 @@ test:
 
 thread-exception:
 	docker build -t thread-exception -f Dockerfile-thread-exception ..
+
+config-from-consul:
+	docker build -t config-from-consul -f Dockerfile-config-from-consul ..

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -7,7 +7,7 @@ myservice:
 	docker build -t myservice -f Dockerfile-myservice ..
 
 test-setup: myservice thread-exception egg-info
-	docker pull consul
+	docker pull consul:1.0.7
 	docker pull rabbitmq
 	docker pull wazopbx/wait
 	docker pull python:3.7-slim-buster

--- a/integration_tests/assets/bin/config-from-consul.py
+++ b/integration_tests/assets/bin/config-from-consul.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from flask import Flask, jsonify
+
+from xivo.chain_map import ChainMap
+from xivo.config_helper import read_config_file_hierarchy
+
+app = Flask('myservice')
+
+
+_DEFAULT_CONFIG = {
+    'config_file': '/etc/config-from-consul/config.yml',
+    'extra_config_files': '/etc/config-from-consul/conf.d',
+}
+
+
+def get_config():
+    return ChainMap(read_config_file_hierarchy(_DEFAULT_CONFIG), _DEFAULT_CONFIG).data
+
+
+@app.route('/0.1/config')
+def config():
+    return jsonify(get_config())
+
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", port=6363)

--- a/integration_tests/assets/docker-compose.config-from-consul.override.yml
+++ b/integration_tests/assets/docker-compose.config-from-consul.override.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  sync:
+    depends_on:
+      - consul
+      - config-from-consul
+    environment:
+        TARGETS: "consul:8500 config-from-consul:6363"

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "5672"
 
   consul:
-    image: consul
+    image: consul:1.0.7
     ports:
       - "8500"
 

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -5,6 +5,16 @@ services:
     environment:
       TIMEOUT: ${INTEGRATION_TEST_TIMEOUT}
 
+  config-from-consul:
+    image: config-from-consul
+    ports:
+      - "6363"
+    environment:
+      WAZO_CONSUL_HOST: consul
+      WAZO_CONSUL_PORT: 8500
+      WAZO_CONSUL_SCHEME: http
+      WAZO_CONSUL_SERVICE: config-from-consul
+
   myservice:
     image: myservice
 
@@ -14,10 +24,9 @@ services:
       - "5672"
 
   consul:
-    image: progrium/consul
+    image: consul
     ports:
       - "8500"
-    command: "-client 0.0.0.0 -config-dir /tmp"
 
   thread-exception:
     image: thread-exception

--- a/integration_tests/assets/etc/config-from-consul/conf.d/00-from-consul.yml
+++ b/integration_tests/assets/etc/config-from-consul/conf.d/00-from-consul.yml
@@ -1,0 +1,2 @@
+!exec
+command: /usr/local/bin/wazo-config-from-consul

--- a/integration_tests/suite/test_config_from_consul.py
+++ b/integration_tests/suite/test_config_from_consul.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+import os
+import requests
+
+from consul import Consul
+from hamcrest import assert_that, equal_to
+from xivo_test_helpers.asset_launching_test_case import AssetLaunchingTestCase
+
+
+ASSET_ROOT = os.path.join(os.path.dirname(__file__), '..', 'assets')
+
+
+class TestConfigFromConsul(AssetLaunchingTestCase):
+
+    assets_root = ASSET_ROOT
+    asset = 'config-from-consul'
+    service = 'xivo'
+
+    def test_config_is_propagated(self):
+        app_port = self.service_port(6363, service_name='config-from-consul')
+        config = requests.get("http://localhost:{}/0.1/config".format(app_port)).json()
+        expected_config = {
+            'config_file': '/etc/config-from-consul/config.yml',
+            'extra_config_files': '/etc/config-from-consul/conf.d',
+        }
+        assert_that(config, equal_to(expected_config))
+
+        consul_port = self.service_port(8500, service_name='consul')
+        client = Consul(host="localhost", port=consul_port, scheme="http")
+        client.kv.put("config-from-consul/rest_api/listen", "0.0.0.0")
+        client.kv.put("config-from-consul/rest_api/port", "6363")
+        client.kv.put("other_service/rest_api/port", "1234")
+
+        self.restart_service('config-from-consul')
+
+        app_port = self.service_port(6363, service_name='config-from-consul')
+        config = requests.get("http://localhost:{}/0.1/config".format(app_port)).json()
+
+        expected_config['rest_api'] = {'listen': '0.0.0.0', 'port': '6363'}
+
+        assert_that(config, equal_to(expected_config))
+
+    def test_service_dont_exist(self):
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flask==1.0.2
 netifaces==0.10.4
 psycopg2==2.7.7
 pyyaml==3.13
-python-consul==0.7.1
+python-consul==1.1.0
 marshmallow==3.0.0b14
 six==1.12.0
 stevedore==1.29.0

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,9 @@ setup(
     author_email='dev@wazo.community',
     url='http://wazo.community',
     packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'wazo-config-from-consul = xivo.config_from_consul:get_configuration_from_consul'
+        ]
+    },
 )

--- a/xivo/config_from_consul.py
+++ b/xivo/config_from_consul.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import print_function
+import argparse
+import os
+import sys
+
+import consul
+
+import yaml
+
+
+def get_configuration_from_consul():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Create on-the-fly wazo configuration from Consul key/value storage'
+        )
+    )
+    parser.add_argument(
+        "--scheme",
+        default=os.getenv("WAZO_CONSUL_SCHEME", "http"),
+        help="Scheme to connect to Consul server",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("WAZO_CONSUL_HOST", None),
+        help="Host to connect to Consul server",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=os.getenv("WAZO_CONSUL_PORT", "8500"),
+        help="Port to connect to Consul server",
+    )
+    parser.add_argument(
+        "--service",
+        default=os.getenv("WAZO_CONSUL_SERVICE", "auth"),
+        help="root key where configuration is stored",
+    )
+
+    args = parser.parse_args()
+
+    if args.host is None:
+        print("Neither WAZO_CONSUL_HOST or --host is set, ignoring.", file=sys.stderr)
+        return 0
+
+    client = consul.Consul(host=args.host, port=args.port, scheme=args.scheme)
+    items = client.kv.get(args.service, recurse=True)
+    if not items[1]:
+        print("{} does not exists, ignoring.", file=sys.stderr)
+        return 0
+
+    config = {}
+    for item in items[1]:
+        paths = item["Key"].split("/")[1:]
+        if not paths:
+            continue
+        config_loc = config
+        for path in paths[:-1]:
+            config_loc = config_loc.setdefault(path, {})
+
+        # NOTE(sileht): this assumes we have only dict, no list
+        config_loc[paths[-1]] = item["Value"].decode()
+
+    print(yaml.safe_dump(config, default_flow_style=False, explicit_start=True))
+
+
+if __name__ == '__main__':
+    get_configuration_from_consul()


### PR DESCRIPTION
This change adds a helper command that retrieves wazo service
configuration from consul.

It converts the key/value storage in wazo yaml configuration format.

Any wazo applications, that use xivo.config_helpers, can use it by
creating a file in /etc/wazo-XXXXX/conf.d/from-consul.yml with:

  !exec
  command /usr/bin/wazo-config-from-consul --service service-name --host consul --port 8500 --scheme http

The configuration can also be passed via environment variables:
```
    WAZO_CONSUL_HOST
    WAZO_CONSUL_PORT
    WAZO_CONSUL_SCHEME
    WAZO_CONSUL_SERVICE
```
The following configuration stored in consul:

  `<WAZO_CONSUL_SERVICE>/rest_api/listen = 0.0.0.0`

Will become:
```
---
rest_api:
  listen: 0.0.0.0
```
Current imitation: there is no support of configuration keys that takes
list as value for now.