### PR TITLE
tenant_helpers: add cache for visible_tenants

### DIFF
--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -100,6 +100,14 @@ class TestTenantAutodetect(TestCase):
             calling(Tenant.autodetect).with_args(tokens), raises(UnauthorizedTenant)
         )
 
+    def test_given_visible_tenants_called_twice_with_same_tenant(self):
+        base_tenant = 'base-tenant-uuid'
+        tenant = 'tenant'
+        token = Token(Mock(), Mock())
+        token._cache_tenants = {base_tenant: [tenant]}
+
+        assert_that(token.visible_tenants(base_tenant), equal_to([tenant]))
+
 
 class TestTenantFromHeaders(TestCase):
     @patch('xivo.tenant_helpers.request')


### PR DESCRIPTION
reason: it will avoid to make request twice or more for the same request