### PR TITLE
improve tenant cache to avoid duplicate requests

### DIFF
--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -87,8 +87,7 @@ class Tenant(object):
     def check_against_token(self, token):
         if self.uuid == token.tenant_uuid:
             return self
-        visible_tenants = (tenant.uuid for tenant in token.visible_tenants())
-        if self.uuid not in visible_tenants:
+        if not token.visible_tenants(tenant_uuid=self.uuid):
             raise InvalidTenant(self.uuid)
         return self
 

--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -162,7 +162,7 @@ class TestTenantCheckAgainstToken(TestCase):
 
         assert_that(result.uuid, equal_to(tenant_uuid))
 
-    def test_when_tenant_in_visible_tenants(self):
+    def test_when_visible_tenant_return_values(self):
         tenant = Tenant('subtenant')
         token = Mock(tenant_uuid='supertenant')
         token.visible_tenants.return_value = [
@@ -174,10 +174,19 @@ class TestTenantCheckAgainstToken(TestCase):
 
         assert_that(result.uuid, equal_to('subtenant'))
 
-    def test_when_tenant_not_in_visible_tenants(self):
+    def test_when_visible_tenants_return_error(self):
         tenant = Tenant('othertenant')
         token = Mock(tenant_uuid='supertenant')
-        token.visible_tenants.return_value = [Tenant('subtenant')]
+        token.visible_tenants.side_effect = InvalidTenant()
+
+        assert_that(
+            calling(tenant.check_against_token).with_args(token), raises(InvalidTenant)
+        )
+
+    def test_when_no_visible_tenants(self):
+        tenant = Tenant('othertenant')
+        token = Mock(tenant_uuid='supertenant')
+        token.visible_tenants.return_value = []
 
         assert_that(
             calling(tenant.check_against_token).with_args(token), raises(InvalidTenant)


### PR DESCRIPTION
reason: tenant check_against_token can be implemented by trying to list
this specific tenant. If user has access to see it, then it's because
it's part of his sub tenant. Moreover, by doing this way, it will
initialized cache with a value that will prevent a second call to
visible_tenants(tenant_uuid=<tenant-uuid-to-verify)