### PR TITLE
WAZO-2250 Pull request for extract-tenant-from-query

### DIFF
--- a/xivo/tenant_flask_helpers.py
+++ b/xivo/tenant_flask_helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -49,10 +49,6 @@ current_user = LocalProxy(get_current_user)
 class Tenant(tenant_helpers.Tenant):
     @classmethod
     def autodetect(cls):
-        return cls.autodetect_one()
-
-    @classmethod
-    def autodetect_one(cls):
         try:
             tenant = cls.from_headers()
         except tenant_helpers.InvalidTenant:

--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -65,6 +65,14 @@ class Tenant(object):
             return tenant.check_against_token(token)
         except InvalidTenant:
             raise UnauthorizedTenant(tenant.uuid)
+
+    @classmethod
+    def from_query(cls):
+        try:
+            tenant_uuid = request.args['tenant']
+        except KeyError:
+            raise InvalidTenant()
+        return cls(uuid=tenant_uuid)
 
     @classmethod
     def from_headers(cls):

--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -122,6 +122,23 @@ class TestTenantFromHeaders(TestCase):
         request.headers = {'Wazo-Tenant': tenant}
 
         result = Tenant.from_headers()
+
+        assert_that(result.uuid, equal_to(tenant))
+
+
+class TestTenantFromQuery(TestCase):
+    @patch('xivo.tenant_helpers.request')
+    def test_given_no_tenant_when_from_query_then_raise(self, request):
+        request.args = {}
+
+        assert_that(calling(Tenant.from_query), raises(InvalidTenant))
+
+    @patch('xivo.tenant_helpers.request')
+    def test_given_tenant_when_from_query_then_return_tenant(self, request):
+        tenant = 'tenant'
+        request.args = {'tenant': tenant}
+
+        result = Tenant.from_query()
 
         assert_that(result.uuid, equal_to(tenant))
 


### PR DESCRIPTION
reason: used by cdr recording to be able to set tenant from
query string. To allow to download media directly by the browser
(without headers)