### PR TITLE
asterisk proto: allow to have star code in interface

### DIFF
--- a/xivo/asterisk/protocol_interface.py
+++ b/xivo/asterisk/protocol_interface.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import collections
 import re
 
-channel_regexp = re.compile(r'(sip|sccp|local|dahdi|iax2)/([\w@/-]+)-', re.I)
+channel_regexp = re.compile(r'(sip|sccp|local|dahdi|iax2)/([*\w@/-]+)-', re.I)
 agent_channel_regex = re.compile(r'Local/id-(\d+)@agentcallback')
 device_regexp = re.compile(r'(sip|sccp|local|dahdi|iax2)/([\w@/-]+)', re.I)
 

--- a/xivo/asterisk/tests/test_protocol_interface.py
+++ b/xivo/asterisk/tests/test_protocol_interface.py
@@ -117,3 +117,12 @@ class TestProtocolInterface(unittest.TestCase):
         result = protocol_interface_from_channel(channel)
 
         self.assertEqual(result, expected_result)
+
+    def test_star_code_in_interface(self):
+        channel = 'Local/**96**996666@internal-00000006;1'
+
+        expected_result = ProtocolInterface('Local', '**96**996666@internal')
+
+        result = protocol_interface_from_channel(channel)
+
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
This lib is now used by call-logd to extract protocol and interface