### PR TITLE
Pull request for WAZO-2315-factorize-access-check

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -183,15 +183,15 @@ def extract_token_id_from_query_or_header():
 
 
 class AccessCheck:
-    def __init__(self, auth_id, acl):
+    def __init__(self, auth_id, session_id, acl):
         self.auth_id = auth_id
         self._positive_access_regexes = [
-            self._transform_access_to_regex(auth_id, access)
+            self._transform_access_to_regex(auth_id, session_id, access)
             for access in acl
             if not access.startswith('!')
         ]
         self._negative_access_regexes = [
-            self._transform_access_to_regex(auth_id, access[1:])
+            self._transform_access_to_regex(auth_id, session_id, access[1:])
             for access in acl
             if access.startswith('!')
         ]
@@ -210,12 +210,12 @@ class AccessCheck:
         return False
 
     @staticmethod
-    def _transform_access_to_regex(auth_id, token_id, access):
+    def _transform_access_to_regex(auth_id, session_id, access):
         access_regex = re.escape(access).replace('\\*', '[^.]*?').replace('\\#', '.*?')
         access_regex = AccessCheck._replace_reserved_words(
             access_regex,
             ReservedWord('me', auth_id),
-            ReservedWord('my_token', token_id),
+            ReservedWord('my_session', session_id),
         )
         return re.compile('^{}$'.format(access_regex))
 

--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import re
 import requests
 
 from collections import namedtuple
@@ -179,3 +180,50 @@ def extract_token_id_from_query_string():
 
 def extract_token_id_from_query_or_header():
     return extract_token_id_from_query_string() or extract_token_id_from_header()
+
+
+class AccessCheck:
+    def __init__(self, auth_id, acl):
+        self.auth_id = auth_id
+        self.acl = acl
+
+    def matches_required_access(self, required_access):
+        if required_access is None:
+            return True
+
+        positive_user_acl = set()
+        negative_user_acl = set()
+
+        for user_access in self.acl:
+            if user_access.startswith('!'):
+                negative_user_acl.add(user_access[1:])
+            else:
+                positive_user_acl.add(user_access)
+
+        for negative_access in negative_user_acl:
+            negative_access_regex = self._transform_access_to_regex(negative_access)
+            if re.match(negative_access_regex, required_access):
+                return False
+
+        for positive_access in positive_user_acl:
+            positive_access_regex = self._transform_access_to_regex(positive_access)
+            if re.match(positive_access_regex, required_access):
+                return True
+        return False
+
+    def _transform_access_to_regex(self, access):
+        access_regex = re.escape(access)
+        access_regex = access_regex.replace('\\*', '[^.]*?').replace('\\#', '.*?')
+        access_regex = self._transform_access_me_to_uuid_or_me(access_regex)
+        return re.compile('^{}$'.format(access_regex))
+
+    def _transform_access_me_to_uuid_or_me(self, access_regex):
+        access_regex = access_regex.replace(
+            '\\.me\\.', '\\.(me|{auth_id})\\.'.format(auth_id=self.auth_id)
+        )
+        if access_regex.endswith('\\.me'):
+            access_regex = '{access_start}\\.(me|{auth_id})'.format(
+                access_start=access_regex[:-4],
+                auth_id=self.auth_id,
+            )
+        return access_regex


### PR DESCRIPTION
## auth_verifier: extract AccessCheck from wazo-auth

Why:

* Logic can be shared across daemons

## auth_verifier: refactor AccessCheck

Why:

* Incorporate code from wazo-websocketd that is simpler and or clearer

## auth_verifier: refactor access special word


## auth_verifier: replace word "my_session" in ACL