### PR TITLE
remove python-consul dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,6 @@ Replaces:  pf-xivo-lib-python
 Conflicts: pf-xivo-lib-python
 Depends: ${python:Depends},
          ${misc:Depends},
-         python-consul,
          python-psycopg2,
          python-six,
          python-yaml


### PR DESCRIPTION
Why:

* python-consul package is not used (no Python 2 service needs Consul)
* python-consul package can't compile correctly (invalid syntax) with
Python 2