### PR TITLE
verify_tenant: return 401 if no token

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -130,9 +130,12 @@ class AuthVerifier(object):
             if not required_tenant:
                 return func(*args, **kwargs)
             token_id = self.token()
+
             try:
                 token = self.client().token.get(token_id)
             except requests.RequestException as e:
+                if e.response is not None and e.response.status_code == 404:
+                    return self.handle_unauthorized(token_id)
                 return self.handle_unreachable(e)
 
             tenant_uuid = token.get('metadata', {}).get('tenant_uuid')

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -215,6 +215,23 @@ class TestAuthVerifier(unittest.TestCase):
 
         assert_that(result, equal_to(s.unauthorized))
 
+    def test_verify_tenant_calls_handle_unauthorized_when_404(self):
+        mock_client = Mock()
+        response = Mock(status_code=404)
+        exception = requests.RequestException(response=response)
+        mock_client.token.get.side_effect = exception
+        auth_verifier = StubVerifier()
+        auth_verifier.set_client(mock_client)
+
+        @auth_verifier.verify_tenant
+        @required_tenant('foo')
+        def decorated():
+            return s.result
+
+        result = decorated()
+
+        assert_that(result, equal_to(s.unauthorized))
+
     @patch('xivo.auth_verifier.request')
     def test_token_empty(self, request):
         request.headers = {}


### PR DESCRIPTION
reason: we don't want to return 404 if invalid token is provided because
it doesn't exist