### PR TITLE
protocol_interface: accept pjsip interface

### DIFF
--- a/xivo/asterisk/protocol_interface.py
+++ b/xivo/asterisk/protocol_interface.py
@@ -5,7 +5,7 @@
 import collections
 import re
 
-channel_regexp = re.compile(r'(sip|sccp|local|dahdi|iax2)/([*\w@/-]+)-', re.I)
+channel_regexp = re.compile(r'(pjsip|sip|sccp|local|dahdi|iax2)/([*\w@/-]+)-', re.I)
 agent_channel_regex = re.compile(r'Local/id-(\d+)@agentcallback')
 device_regexp = re.compile(r'(sip|sccp|local|dahdi|iax2)/([\w@/-]+)', re.I)
 
@@ -27,6 +27,11 @@ def protocol_interface_from_channel(channel):
 
     protocol = matches.group(1)
     interface = matches.group(2)
+
+    if protocol == 'pjsip':
+        protocol = 'sip'
+    elif protocol == 'PJSIP':
+        protocol = 'SIP'
 
     return ProtocolInterface(protocol, interface)
 

--- a/xivo/asterisk/tests/test_protocol_interface.py
+++ b/xivo/asterisk/tests/test_protocol_interface.py
@@ -41,6 +41,22 @@ class TestProtocolInterface(unittest.TestCase):
 
         assert_that(result, contains_exactly(expected_result))
 
+    def test_protocol_interface_from_channel_pjsip_lower(self):
+        channel = 'pjsip/askdjhf-3216549'
+        expected_result = ProtocolInterface('sip', 'askdjhf')
+
+        result = protocol_interface_from_channel(channel)
+
+        self.assertEqual(expected_result, result)
+
+    def test_protocol_interface_from_channel_pjsip(self):
+        channel = 'PJSIP/askdjhf-3216549'
+        expected_result = ProtocolInterface('SIP', 'askdjhf')
+
+        result = protocol_interface_from_channel(channel)
+
+        self.assertEqual(expected_result, result)
+
     def test_protocol_interface_from_channel_sip(self):
         channel = 'SIP/askdjhf-3216549'
         expected_result = ProtocolInterface('SIP', 'askdjhf')


### PR DESCRIPTION
why: because pjsip migration code has been removed and now, interface can
be PJSIP/abc