### PR TITLE
Pull request for WAZO-2530-auth-allow-adding-negative-acl

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -215,6 +215,9 @@ class AccessCheck:
                 return True
         return False
 
+    def may_add_access(self, new_access):
+        return new_access.startswith('!') or self.matches_required_access(new_access)
+
     @staticmethod
     def _transform_access_to_regex(auth_id, session_id, access):
         access_regex = re.escape(access).replace('\\*', '[^.#]*?').replace('\\#', '.*?')

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -438,6 +438,23 @@ class TestAccessCheck(object):
         check = AccessCheck('123', 'session-uuid', acl)
         assert_that(check.matches_required_access(access), is_(expected_result))
 
+    def test_matches_required_access_with_negative_access(self):
+        check = AccessCheck('123', 'session-uuid', ['foo.bar'])
+
+        assert_that(check.matches_required_access('!foo.bar'), is_(False))
+        assert_that(check.matches_required_access('!anything'), is_(False))
+
+    @pytest.mark.parametrize(['acl', 'access', 'expected_result'], parameters)
+    def test_may_add_access(self, acl, access, expected_result):
+        check = AccessCheck('123', 'session-uuid', acl)
+        assert_that(check.may_add_access(access), is_(expected_result))
+
+    def test_may_add_access_with_negative_access(self):
+        check = AccessCheck('123', 'session-uuid', ['foo.bar'])
+
+        assert_that(check.may_add_access('!foo.bar'), is_(True))
+        assert_that(check.may_add_access('!anything'), is_(True))
+
     @unittest.skipIf(six.PY2, "not compatible with Python <3.3 (_ is re.escaped)")
     def test_matches_my_session(self):
         check = AccessCheck('123', 'session-uuid', ['foo.my_session'])


### PR DESCRIPTION
## tests auth_verifier: refactor scenarios

Why:

* Will be needed for a new method

## auth_verifier: explicitly check if access can be added from ACL

Why:

* The logic is different when checking if access is allowed and when
checking if access can be added