### PR TITLE
tests: update consul docker image

### DIFF
--- a/integration_tests/Dockerfile-myservice
+++ b/integration_tests/Dockerfile-myservice
@@ -3,13 +3,10 @@ FROM python:3.7-buster
 COPY integration_tests/assets/bin /usr/local/bin
 COPY . /tmp/xivo
 
-RUN pip install \
-    kombu \
-    flask \
-    https://github.com/wazo-platform/xivo-bus/archive/master.zip \
-    python-consul==0.7.1 \
-    netifaces
-
-RUN cd /tmp/xivo && python setup.py install
+WORKDIR /tmp/xivo
+RUN true && \
+    pip install -r requirements.txt kombu netifaces && \
+    python setup.py install && \
+    true
 
 CMD ["myservice.py"]

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       - "5672"
 
   consul:
-    image: progrium/consul
+    image: consul:1.0.7
     ports:
       - "8500"
-    command: "-client 0.0.0.0 -config-dir /tmp"
+    command: "agent -server -client 0.0.0.0 -bootstrap-expect=1"
 
   thread-exception:
     image: thread-exception

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -3,4 +3,4 @@ docker-compose
 kombu==4.6.11
 pyhamcrest
 pytest
-python-consul==0.7.1
+python-consul==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flask==1.0.2
 netifaces==0.10.4
 psycopg2==2.7.7
 pyyaml==3.13
-python-consul==0.7.1
+python-consul==1.1.0
 marshmallow==3.0.0b14
 six==1.12.0
 stevedore==1.29.0


### PR DESCRIPTION
Why:

* Use the correct version of consul
* python-consul 0.7 is not compatible with consul 1.0.7
* We are using python-consul 1.1.0 in Wazo Platform