### PR TITLE
pin jinja2 and marksupsafe to buster version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ https://github.com/wazo-platform/xivo-bus/archive/master.zip
 cheroot==6.5.4
 flask==1.0.2
 itsdangerous==0.24  # from flask
+jinja2==2.10  # from flask
+markupsafe==1.1.0 # from flask
 marshmallow==3.0.0b14; python_version <= '2.7'
 marshmallow==3.10.0; python_version >= '3.6'
 netifaces==0.10.4


### PR DESCRIPTION
why: latest jinja2 version (3.1.0) is incompatible with flask 1.0.2
(from buster)

and newer markupsafe versions (> 2) are incompatible with buster jinja2