### PR TITLE
config_helper: add config parser accumulating lists

### DIFF
--- a/xivo/chain_map.py
+++ b/xivo/chain_map.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from copy import copy
@@ -22,5 +22,20 @@ class ChainMap(UserDict):
                 updated[key] = copy(value)
             elif isinstance(updated[key], dict) and isinstance(value, dict):
                 updated[key] = self._deep_update(updated[key], value)
+
+        return updated
+
+
+class AccumulatingListChainMap(ChainMap):
+    def _deep_update(self, original, new):
+        updated = copy(original)
+
+        for key, value in new.items():
+            if key not in updated:
+                updated[key] = copy(value)
+            elif isinstance(updated[key], dict) and isinstance(value, dict):
+                updated[key] = self._deep_update(updated[key], value)
+            elif isinstance(updated[key], list) and isinstance(value, list):
+                updated[key].extend(copy(value))
 
         return updated

--- a/xivo/config_helper.py
+++ b/xivo/config_helper.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import print_function
@@ -11,7 +11,7 @@ import subprocess
 
 import yaml
 
-from .chain_map import ChainMap
+from .chain_map import AccumulatingListChainMap, ChainMap
 
 
 class _YAMLExecLoader(yaml.SafeLoader):
@@ -130,6 +130,17 @@ class ConfigParser(object):
 
         return ChainMap(*configs)
 
+    def read_config_file_hierarchy_accumulating_list(self, original_config):
+        main_config_filename = original_config['config_file']
+        main_config = self.parse_config_file(main_config_filename)
+        extra_config_file_directory = AccumulatingListChainMap(
+            main_config, original_config
+        )['extra_config_files']
+        configs = self.parse_config_dir(extra_config_file_directory)
+        configs.append(main_config)
+
+        return AccumulatingListChainMap(*configs)
+
 
 class UUIDNotFound(RuntimeError):
     def __init__(self):
@@ -153,3 +164,6 @@ _config_parser = ConfigParser()
 parse_config_file = _config_parser.parse_config_file
 parse_config_dir = _config_parser.parse_config_dir
 read_config_file_hierarchy = _config_parser.read_config_file_hierarchy
+read_config_file_hierarchy_accumulating_list = (
+    _config_parser.read_config_file_hierarchy_accumulating_list
+)


### PR DESCRIPTION
Why:

* So that lists can be appended from drop-in config files