### PR TITLE
fix generated docker-compose project name

### DIFF
--- a/integration_tests/suite/test_service_discovery.py
+++ b/integration_tests/suite/test_service_discovery.py
@@ -81,7 +81,7 @@ class _BaseTest(AssetLaunchingTestCase):
         status = self.service_status('myservice')
 
         try:
-            network_name = '{}_default'.format(self.service)
+            network_name = f'{self.service}_{self.asset}_default'
             yield ip or status['NetworkSettings']['Networks'][network_name]['IPAddress']
         finally:
             id_ = status['Id']


### PR DESCRIPTION
why: the name of project now include asset name