### PR TITLE
mallow: hardcode original format string for error

### DIFF
--- a/xivo/mallow/fields.py
+++ b/xivo/mallow/fields.py
@@ -88,7 +88,7 @@ class DateTime(_DateTime):
     default_error_messages.update(
         {
             'invalid': _StringifiedDict(
-                message=_DateTime.default_error_messages['invalid'],
+                message='Not a valid datetime',
                 constraint_id='type',
                 constraint='datetime',
             )
@@ -197,7 +197,7 @@ class TimeDelta(_TimeDelta):
                 constraint='timedelta',
             ),
             'format': _StringifiedDict(
-                message=_TimeDelta.default_error_messages['format'],
+                message='Cannot be formatted as a timedelta',
                 constraint_id='type',
                 constraint='format',
             ),


### PR DESCRIPTION
why: original message is format string which is populated when calling
`make_error`. Overriding this method imply code change in all fields and
maintain the implementation in wazo side, which doesn't worth it.