### PR TITLE
tox: allow overriding pytest args

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = py27, py37, pycodestyle, pylint
 
 [testenv]
 commands =
-    pytest --junitxml=unit-tests.xml --cov=xivo --cov-report term --cov-report xml:coverage.xml xivo
+    pytest {posargs:--junitxml=unit-tests.xml --cov=xivo --cov-report term --cov-report xml:coverage.xml xivo}
 deps =
     -rrequirements.txt
     -rtest-requirements.txt


### PR DESCRIPTION
Why:

* Less clutter in the output when developing