### PR TITLE
adapt tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 
 [testenv:integration]
 basepython = python3.7
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests
 passenv =
@@ -42,7 +42,7 @@ passenv =
 commands =
     make test-setup
     pytest -v {posargs}
-whitelist_externals =
+allowlist_externals =
     make
     sh
 


### PR DESCRIPTION
Why:

* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals