### PR TITLE
Update to use Python 3.9 on bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Running unit tests
 ------------------
 
 ```
-apt-get install libpq-dev libffi-dev libyaml-dev python3.7-dev
+apt-get install libpq-dev libffi-dev libyaml-dev python3-dev
 pip install tox
-tox --recreate -e py37
+tox --recreate -e py39
 ```
 
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Wazo Maintainers <dev@wazo.community>
 Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools
 Standards-Version: 3.9.6
-X-Python3-Version: >= 3.7
+X-Python3-Version: >= 3.9
 
 Package: xivo-lib-python-python3
 Architecture: all

--- a/integration_tests/Dockerfile-myservice
+++ b/integration_tests/Dockerfile-myservice
@@ -1,13 +1,12 @@
-FROM python:3.7-buster
+FROM python:3.9-bullseye
 
 COPY integration_tests/assets/bin /usr/local/bin
 COPY . /tmp/xivo
 
 WORKDIR /tmp/xivo
 
-# importlib_metadata<5.0.0  # from kombu - https://github.com/celery/kombu/issues/1600
 RUN true && \
-    pip install -r requirements.txt kombu 'importlib_metadata<5.0.0' && \
+    pip install -r requirements.txt kombu && \
     python setup.py install && \
     true
 

--- a/integration_tests/Dockerfile-thread-exception
+++ b/integration_tests/Dockerfile-thread-exception
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.9-slim-bullseye
 
 COPY integration_tests/assets/bin/thread-exception.py /usr/local/bin
 COPY . /usr/local/src/xivo-lib-python

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "5672"
 
   consul:
-    image: consul:1.0.7
+    image: consul:1.8.7
     ports:
       - "8500"
     command: "agent -server -client 0.0.0.0 -bootstrap-expect=1"

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,6 +1,5 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-importlib_metadata==1.6.0  # from kombu
-kombu==4.6.11
+kombu==5.0.2
 pyhamcrest
 pytest
 python-consul==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
 https://github.com/wazo-platform/xivo-bus/archive/master.zip
-cheroot==6.5.4
-flask==1.0.2
-itsdangerous==0.24  # from flask
-jinja2==2.10  # from flask
-markupsafe==1.1.0 # from flask
+cheroot==8.5.2
+flask==1.1.2
+itsdangerous==1.1.0  # from flask
+jinja2==2.11.3  # from flask
+markupsafe==1.1.1 # from flask
+werkzeug==1.0.1 # from flask
 marshmallow==3.10.0
-netifaces==0.10.4
+netifaces==0.10.9
 python-consul==1.1.0
-pyyaml==3.13
-stevedore==1.29.0
+pyyaml==5.3.1
+stevedore==3.2.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-importlib_metadata<5.0.0  # from kombu - https://github.com/celery/kombu/issues/1600
 kombu
 pyhamcrest
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,18 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, linters
+envlist = py39, linters
 
 [testenv]
-basepython = python3.7
 commands =
-    pytest --junitxml=unit-tests.xml --cov=xivo --cov-report term --cov-report xml:coverage.xml xivo
+    pytest --junitxml=unit-tests.xml --cov=xivo --cov-report term --cov-report xml:coverage.xml xivo {posargs}
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pytest-cov
 
 [testenv:integration]
-basepython = python3.7
+basepython = python3.9
 use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -48,7 +48,7 @@ class StubVerifier(AuthVerifier):
 
 class TestAuthVerifier(unittest.TestCase):
     def setUp(self):
-        self.patcher = patch('xivo.auth_verifier.request')
+        self.patcher = patch('xivo.auth_verifier.request', Mock())
         self.request_mock = self.patcher.start()
         del self.request_mock.token_id
         del self.request_mock._token_content
@@ -59,9 +59,7 @@ class TestAuthVerifier(unittest.TestCase):
 
     def test_set_client(self):
         auth_verifier = AuthVerifier()
-
         auth_verifier.set_client(s.client)
-
         assert_that(auth_verifier.client(), equal_to(s.client))
 
     @patch('xivo.auth_verifier.Client')

--- a/xivo/tests/test_http_helpers.py
+++ b/xivo/tests/test_http_helpers.py
@@ -21,48 +21,72 @@ def _assert_json_equals(result, expected):
 
 
 class TestLogRequest(unittest.TestCase):
-    @patch('xivo.http_helpers.current_app')
-    @patch('xivo.http_helpers.g')
-    @patch('xivo.http_helpers.request')
-    def test_log_request(self, request, g, current_app):
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_request(self, g):
         del g.request_time
-        request.url = '/foo/bar?token=1734768e-caf6'
+        mock_request = Mock()
+        mock_request.url = '/foo/bar?token=1734768e-caf6'
         response = Mock(data=None, status_code=200)
 
-        log_request(response)
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_request(response)
 
-        current_app.logger.info.assert_called_once_with(
-            ANY, request.remote_addr, '', request.method, request.url, 200
-        )
+            mock_current_app.logger.info.assert_called_once_with(
+                ANY,
+                mock_request.remote_addr,
+                '',
+                mock_request.method,
+                mock_request.url,
+                200,
+            )
 
-    @patch('xivo.http_helpers.current_app')
-    @patch('xivo.http_helpers.g')
-    @patch('xivo.http_helpers.request')
-    def test_log_request_hide_token(self, request, g, current_app):
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_request_hide_token(self, g):
         del g.request_time
-        request.url = '/foo/bar?token=1734768e-caf6'
+        mock_request = Mock()
+        mock_request.url = '/foo/bar?token=1734768e-caf6'
         response = Mock(data=None, status_code=200)
 
-        log_request_hide_token(response)
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_request_hide_token(response)
 
-        expected_url = '/foo/bar?token=<hidden>'
-        current_app.logger.info.assert_called_once_with(
-            ANY, request.remote_addr, '', request.method, expected_url, 200
-        )
+            expected_url = '/foo/bar?token=<hidden>'
+            mock_current_app.logger.info.assert_called_once_with(
+                ANY,
+                mock_request.remote_addr,
+                '',
+                mock_request.method,
+                expected_url,
+                200,
+            )
 
-    @patch('xivo.http_helpers.current_app')
-    @patch('xivo.http_helpers.g')
-    @patch('xivo.http_helpers.request')
-    def test_log_with_duration(self, request, g, current_app):
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_with_duration(self, g):
         g.request_time = 1667410149.0782132
-        request.url = '/foo/bar'
+        mock_request = Mock()
+        mock_request.url = '/foo/bar'
         response = Mock(data=None, status_code=200)
 
-        log_request(response)
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_request(response)
 
-        current_app.logger.info.assert_called_once_with(
-            ANY, request.remote_addr, ANY, request.method, request.url, 200
-        )
+            mock_current_app.logger.info.assert_called_once_with(
+                ANY,
+                mock_request.remote_addr,
+                ANY,
+                mock_request.method,
+                mock_request.url,
+                200,
+            )
 
 
 class TestBodyFormatter(unittest.TestCase):

--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -32,7 +32,7 @@ from ..tenant_helpers import (
 
 
 class TestTenantAutodetect(TestCase):
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_no_token_when_autodetect_then_raise(self, request):
         tokens = Mock()
         tokens.from_headers.side_effect = InvalidToken
@@ -40,7 +40,7 @@ class TestTenantAutodetect(TestCase):
 
         assert_that(calling(Tenant.autodetect).with_args(tokens), raises(InvalidToken))
 
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_token_no_tenant_when_autodetect_then_return_tenant_from_token(
         self, request
     ):
@@ -53,7 +53,7 @@ class TestTenantAutodetect(TestCase):
 
         assert_that(result.uuid, equal_to(tenant))
 
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_token_and_tenant_when_autodetect_then_return_given_tenant(
         self, request
     ):
@@ -68,7 +68,7 @@ class TestTenantAutodetect(TestCase):
 
         assert_that(result.uuid, equal_to(tenant))
 
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_token_unknown_tenant_and_user_in_tenant_when_autodetect_then_return_tenant(
         self, request
     ):
@@ -84,7 +84,7 @@ class TestTenantAutodetect(TestCase):
 
         assert_that(result.uuid, equal_to(tenant))
 
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_token_unknown_tenant_and_user_not_in_tenant_when_autodetect_then_raise(
         self, request
     ):
@@ -110,13 +110,13 @@ class TestTenantAutodetect(TestCase):
 
 
 class TestTenantFromHeaders(TestCase):
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_no_tenant_when_from_headers_then_raise(self, request):
         request.headers = {}
 
         assert_that(calling(Tenant.from_headers), raises(InvalidTenant))
 
-    @patch('xivo.tenant_helpers.request')
+    @patch('xivo.tenant_helpers.request', spec={})
     def test_given_tenant_when_from_headers_then_return_tenant(self, request):
         tenant = 'tenant'
         request.headers = {'Wazo-Tenant': tenant}
@@ -127,16 +127,16 @@ class TestTenantFromHeaders(TestCase):
 
 
 class TestTenantFromQuery(TestCase):
-    @patch('xivo.tenant_helpers.request')
-    def test_given_no_tenant_when_from_query_then_raise(self, request):
-        request.args = {}
+    @patch('xivo.tenant_helpers.request', spec={})
+    def test_given_no_tenant_when_from_query_then_raise(self, mock_request):
+        mock_request.args = {}
 
         assert_that(calling(Tenant.from_query), raises(InvalidTenant))
 
-    @patch('xivo.tenant_helpers.request')
-    def test_given_tenant_when_from_query_then_return_tenant(self, request):
+    @patch('xivo.tenant_helpers.request', spec={})
+    def test_given_tenant_when_from_query_then_return_tenant(self, mock_request):
         tenant = 'tenant'
-        request.args = {'tenant': tenant}
+        mock_request.args = {'tenant': tenant}
 
         result = Tenant.from_query()
 

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,9 +1,9 @@
 - project:
     templates:
       - wazo-tox-linters-310
-      - wazo-tox-py37
-      - wazo-tox-integration
-      - debian-packaging-template
+      - wazo-tox-py39
+      - wazo-tox-integration-py39
+      - debian-packaging-bullseye
     vars:
       docker_compose_services_override:
         - thread-exception


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-auth-client/pull/35
Depends-On: https://github.com/wazo-platform/wazo-lib-rest-client/pull/14
Depends-On: https://github.com/wazo-platform/xivo-bus/pull/84