### PR TITLE
mallow: add field type for werkzeug multidict

### DIFF
--- a/xivo/mallow/fields.py
+++ b/xivo/mallow/fields.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -213,3 +213,13 @@ class IP(_String):
             return str(ipaddress.ip_address(value))
         except ValueError:
             raise self.make_error("invalid")
+
+
+# Copied from https://github.com/marshmallow-code/marshmallow/issues/133
+class MultiDictAwareList(List):
+    def _deserialize(
+        self, value: Any, attr: str | None, data: dict[str, Any], **kwargs: Any
+    ) -> dict[str, list]:
+        if isinstance(data, dict) and hasattr(data, 'getlist'):
+            value = data.getlist(attr)
+        return super()._deserialize(value, attr, data, **kwargs)


### PR DESCRIPTION
this field will always return a list wether the input was a str or a list of str