### PR TITLE
WP-1476 improve authentication/tenant workflow

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -194,6 +194,7 @@ class AuthVerifier:
         return wrapper
 
     def _add_request_properties(self, token_id: str) -> None:
+        # NOTE(fblackburn): Token is only fetched if/when properties are used
         request.token_id = token_id
         request._get_token_content = self._get_token_content
         request._get_user_uuid = self._get_user_uuid

--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -186,14 +186,10 @@ class AuthVerifier:
             except requests.RequestException as e:
                 return self.handle_unreachable(e)
 
-            if token_is_valid:
-                return func(*args, **kwargs)
+            if not token_is_valid:
+                raise NotImplementedError('Invalid token without exception')
 
-            # NOTE(pc-m): This "should" be unreachable. is_valid can only return True or raise
-            # I've left this logger to avoid debugging for hours if I'm mistaken and a resource
-            # returns doing nothing silently
-            logger.warning("This is a bug")
-            return None
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/xivo/tenant_flask_helpers.py
+++ b/xivo/tenant_flask_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from flask import current_app, g
 from wazo_auth_client import Client as AuthClient
 from werkzeug.local import LocalProxy
 
-from xivo.tenant_helpers import Token, Tokens, User, Users
+from xivo.tenant_helpers import Token, Tokens
 
 from . import tenant_helpers
 
@@ -36,17 +36,6 @@ def get_token() -> Token:
 
 
 token: Token = LocalProxy(get_token)  # type: ignore[assignment]
-
-
-def get_current_user() -> User:
-    current_user = g.get('current_user')
-    if not current_user:
-        auth_client.set_token(token.uuid)
-        current_user = g.current_user = Users(auth_client).get(token.user_uuid)
-    return current_user
-
-
-current_user: User = LocalProxy(get_current_user)  # type: ignore[assignment]
 
 Self = TypeVar('Self', bound='Tenant')
 

--- a/xivo/tenant_flask_helpers.py
+++ b/xivo/tenant_flask_helpers.py
@@ -23,7 +23,6 @@ def get_auth_client() -> AuthClient:
     return auth_client
 
 
-# TODO: When werkzeug is updated it the ignore can be removed.
 auth_client: AuthClient = LocalProxy(get_auth_client)
 
 

--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -94,8 +94,6 @@ class Tenant:
         self.name = name
 
     def check_against_token(self: Self, token: Token) -> Self:
-        if self.uuid == token.tenant_uuid:
-            return self
         if not token.has_tenant_access(self.uuid):
             raise InvalidTenant(self.uuid)
         return self

--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -94,7 +94,7 @@ class Tenant:
         self.name = name
 
     def check_against_token(self: Self, token: Token) -> Self:
-        if not token.has_tenant_access(self.uuid):
+        if not token.is_tenant_allowed(self.uuid):
             raise InvalidTenant(self.uuid)
         return self
 
@@ -147,7 +147,7 @@ class Token:
 
         return self.__token_dict
 
-    def has_tenant_access(self, tenant_uuid: str | None) -> bool:
+    def is_tenant_allowed(self, tenant_uuid: str | None) -> bool:
         if not tenant_uuid:
             return False
 

--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -151,6 +151,9 @@ class Token:
         if not tenant_uuid:
             return False
 
+        if self.__token_dict and self.tenant_uuid == tenant_uuid:
+            return True
+
         try:
             return self._auth.token.is_valid(self.uuid, tenant=tenant_uuid)
         except requests.RequestException as e:

--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -111,30 +111,19 @@ class Tokens:
     def __init__(self, auth: Client):
         self._auth = auth
 
-    def get(self, token_id: str) -> Token:
-        try:
-            return Token(self._auth.token.get(token_id), self._auth)
-        except requests.HTTPError:
-            raise InvalidToken(token_id)
-        except requests.RequestException as e:
-            raise AuthServerUnreachable(self._auth.host, self._auth.port, e)
-
     def from_headers(self) -> Token:
         token_id = extract_token_id_from_header()
         if not token_id:
             raise InvalidToken()
-        return self.get(token_id)
+        return Token(token_id, self._auth)
 
 
 class Token:
-    def __init__(self, token_dict: dict[str, Any], auth: Client) -> None:
+    def __init__(self, uuid: str, auth: Client) -> None:
+        self.uuid = uuid
         self._auth = auth
-        self._token_dict = token_dict
+        self.__token_dict: dict[str, Any] | None = None
         self._cache_tenants: dict[str, list[Tenant]] = {}
-
-    @property
-    def uuid(self) -> str:
-        return self._token_dict['token']
 
     @property
     def infos(self) -> dict[str, Any]:
@@ -147,6 +136,18 @@ class Token:
     @property
     def user_uuid(self) -> str | None:
         return self._token_dict['metadata'].get('uuid')
+
+    @property
+    def _token_dict(self) -> dict[str, Any]:
+        if self.__token_dict is None:
+            try:
+                self.__token_dict = self._auth.token.get(self.uuid)
+            except requests.HTTPError:
+                raise InvalidToken(self.uuid)
+            except requests.RequestException as e:
+                raise AuthServerUnreachable(self._auth.host, self._auth.port, e)
+
+        return self.__token_dict
 
     def has_tenant_access(self, tenant_uuid: str | None) -> bool:
         if not tenant_uuid:

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -279,6 +279,22 @@ class TestAuthVerifier(unittest.TestCase):
         result = decorated()
 
         assert_that(result, equal_to(s.unauthorized))
+
+    def test_verify_token_raise_not_implemented_when_invalid_without_raising(self):
+        mock_client = Mock()
+        mock_client.token.check.return_value = False
+        auth_verifier = StubVerifier()
+        auth_verifier.set_client(mock_client)
+
+        @auth_verifier.verify_token
+        @required_acl('foo')
+        def decorated():
+            return s.result
+
+        assert_that(
+            calling(decorated),
+            raises(NotImplementedError),
+        )
 
     def test_token_empty(self):
         self.request_mock.headers = {}

--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -167,15 +167,6 @@ class TestTenantCheckAgainstToken(TestCase):
             calling(tenant.check_against_token).with_args(token), raises(InvalidTenant)
         )
 
-    def test_when_token_has_same_tenant_uuid(self):
-        tenant_uuid = 'tenant'
-        tenant = Tenant(tenant_uuid)
-        token = Mock(tenant_uuid=tenant_uuid)
-
-        result = tenant.check_against_token(token)
-
-        assert_that(result.uuid, equal_to(tenant_uuid))
-
     def test_when_has_tenant_access(self):
         tenant = Tenant('subtenant')
         token = Mock(tenant_uuid='supertenant')

--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -350,6 +350,27 @@ class TestTokenIsTenantAllowed(TestCase):
 
         assert_that(not has_access)
 
+    def test_tenant_is_same_as_token_when_already_fetched(self):
+        auth = Mock()
+        token = Token('token', auth)
+        auth.token.get.return_value = {'metadata': {'tenant_uuid': 'tenant_uuid'}}
+        token.tenant_uuid  # fetch token
+
+        has_access = token.is_tenant_allowed('tenant_uuid')
+
+        auth.token.is_valid.assert_not_called()
+        assert_that(has_access)
+
+    def test_tenant_is_different_as_token_when_already_fetched(self):
+        auth = Mock()
+        token = Token('token', auth)
+        auth.token.get.return_value = {'metadata': {'tenant_uuid': 'tenant_uuid'}}
+        token.tenant_uuid  # fetch token
+
+        token.is_tenant_allowed('other_uuid')
+
+        auth.token.is_valid.assert_called_once_with('token', tenant='other_uuid')
+
 
 class TestTokenProperties(TestCase):
     def test_token_dict_cached(self):

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -4,6 +4,7 @@
       - wazo-tox-py39
       - wazo-tox-integration-py39
       - debian-packaging-bullseye
+      - wazo-acceptance-bullseye
     vars:
       docker_compose_services_override:
         - thread-exception


### PR DESCRIPTION
Remove one query to wazo-auth when `Wazo-Tenant` is provided
And the query sent is now a `HEAD /tokens` instead of `GET /tenants` which is a lot faster