### PR TITLE
validate and share tenant_uuid from verify_token with autodetect

### DIFF
--- a/xivo/flask/auth_verifier.py
+++ b/xivo/flask/auth_verifier.py
@@ -10,7 +10,7 @@ from flask import g
 from ..auth_verifier import AuthVerifierHelpers
 from ..http_exceptions import InvalidTokenAPIException, Unauthorized
 from ..tenant_flask_helpers import auth_client, token
-from .headers import extract_token_id_from_header
+from .headers import extract_tenant_id_from_header, extract_token_id_from_header
 
 R = TypeVar('R')
 
@@ -33,7 +33,7 @@ class AuthVerifierFlask:
             self.set_token_extractor(func)
             token_uuid = token.uuid
             required_acl = self.helpers.extract_required_acl(func, kwargs)
-            tenant_uuid = None  # FIXME: Logic not implemented
+            tenant_uuid = extract_tenant_id_from_header() or None
 
             self.helpers.validate_token(
                 auth_client,
@@ -41,6 +41,9 @@ class AuthVerifierFlask:
                 required_acl,
                 tenant_uuid,
             )
+
+            g.verified_tenant_uuid = tenant_uuid
+
             return func(*args, **kwargs)
 
         return wrapper

--- a/xivo/flask/headers.py
+++ b/xivo/flask/headers.py
@@ -15,3 +15,7 @@ def extract_token_id_from_query_string() -> str:
 
 def extract_token_id_from_query_or_header() -> str:
     return extract_token_id_from_query_string() or extract_token_id_from_header()
+
+
+def extract_tenant_id_from_header() -> str:
+    return request.headers.get('Wazo-Tenant', '')

--- a/xivo/flask/tests/test_auth_verifier.py
+++ b/xivo/flask/tests/test_auth_verifier.py
@@ -25,15 +25,20 @@ class TestAuthVerifierFlask(unittest.TestCase):
             'token_extractor': None,
         }
         mock_g.get.side_effect = lambda x: g_data[x]
+        tenant_extractor = Mock(return_value=s.tenant)
 
         @auth_verifier.verify_token
         @required_acl('foo')
         def decorated():
             return s.result
 
-        with patch('xivo.flask.auth_verifier.g', mock_g):
-            with patch('xivo.tenant_flask_helpers.g', mock_g):
-                result = decorated()
+        with patch(
+            'xivo.flask.auth_verifier.extract_tenant_id_from_header',
+            tenant_extractor,
+        ):
+            with patch('xivo.flask.auth_verifier.g', mock_g):
+                with patch('xivo.tenant_flask_helpers.g', mock_g):
+                    result = decorated()
 
         assert result == s.result
 

--- a/xivo/tenant_flask_helpers.py
+++ b/xivo/tenant_flask_helpers.py
@@ -78,6 +78,11 @@ class Tenant(tenant_helpers.Tenant):
             else:
                 logger.debug('Found tenant "%s" from header', tenant.uuid)
 
+        verified_tenant_uuid = g.get('verified_tenant_uuid')
+        if verified_tenant_uuid and tenant and verified_tenant_uuid == tenant.uuid:
+            logger.debug('Tenant already validated by Flask verify_token')
+            return cls(uuid=tenant.uuid)
+
         if not tenant:
             tenant = cls.from_token(token)
             logger.debug('Found tenant "%s" from token', tenant.uuid)

--- a/xivo/tenant_helpers.py
+++ b/xivo/tenant_helpers.py
@@ -13,7 +13,10 @@ from xivo.http_exceptions import AuthServerUnreachable, InvalidTokenAPIException
 try:
     from flask import request
 
-    from .flask.headers import extract_token_id_from_header
+    from .flask.headers import (
+        extract_tenant_id_from_header,
+        extract_token_id_from_header,
+    )
 except ImportError:
     pass
 
@@ -71,9 +74,8 @@ class Tenant:
 
     @classmethod
     def from_headers(cls: type[Self]) -> Self:
-        try:
-            tenant_uuid = request.headers['Wazo-Tenant']
-        except KeyError:
+        tenant_uuid = extract_tenant_id_from_header()
+        if not tenant_uuid:
             raise InvalidTenant()
         return cls(uuid=tenant_uuid)
 

--- a/xivo/tests/test_tenant_flask_helpers.py
+++ b/xivo/tests/test_tenant_flask_helpers.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import Mock, patch
 from unittest.mock import sentinel as s
 
+from ..tenant_flask_helpers import Tenant
 from ..tenant_flask_helpers import auth_client as auth_client_proxy
 
 
@@ -27,3 +28,20 @@ class TestAuthClient(unittest.TestCase):
 
         expected_config = {'host': s.host}
         auth_client.assert_called_once_with(**expected_config)
+
+
+class TestTenant(unittest.TestCase):
+    @patch('xivo.tenant_flask_helpers.AuthClient')
+    def test_autodetect_when_verified_tenant_uuid(self, auth_client):
+        g_mock = Mock()
+        g_data = {'verified_tenant_uuid': s.tenant}
+        g_mock.get.side_effect = lambda x: g_data[x]
+        request_mock = Mock()
+        request_mock.headers.get.return_value = s.tenant
+        request_mock.args = []
+
+        with patch('xivo.tenant_flask_helpers.g', g_mock):
+            with patch('xivo.flask.headers.request', request_mock):
+                tenant = Tenant.autodetect()
+
+        assert tenant.uuid == s.tenant

--- a/xivo/tests/test_tenant_helpers.py
+++ b/xivo/tests/test_tenant_helpers.py
@@ -22,7 +22,7 @@ from ..tenant_helpers import InvalidTenant, Tenant, Token, UnauthorizedTenant
 
 class TestTenantAutodetect(TestCase):
     @patch('xivo.tenant_helpers.Token')
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_no_token_when_autodetect_then_raise(self, request, Token):
         auth = Mock()
         Token.from_headers = Mock()
@@ -35,7 +35,7 @@ class TestTenantAutodetect(TestCase):
         )
 
     @patch('xivo.tenant_helpers.Token')
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_token_no_tenant_when_autodetect_then_return_tenant_from_token(
         self, request, Token
     ):
@@ -51,7 +51,7 @@ class TestTenantAutodetect(TestCase):
         assert_that(result.uuid, equal_to(tenant))
 
     @patch('xivo.tenant_helpers.Token')
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_token_and_tenant_when_autodetect_then_return_given_tenant(
         self, request, Token
     ):
@@ -67,7 +67,7 @@ class TestTenantAutodetect(TestCase):
         assert_that(result.uuid, equal_to(tenant))
 
     @patch('xivo.tenant_helpers.Token')
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_token_unknown_tenant_and_user_in_tenant_when_autodetect_then_return_tenant(
         self, request, Token
     ):
@@ -85,7 +85,7 @@ class TestTenantAutodetect(TestCase):
         assert_that(result.uuid, equal_to(tenant))
 
     @patch('xivo.tenant_helpers.Token')
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_token_unknown_tenant_and_user_not_in_tenant_when_autodetect_then_raise(
         self, request, Token
     ):
@@ -112,13 +112,13 @@ class TestTenantAutodetect(TestCase):
 
 
 class TestTenantFromHeaders(TestCase):
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_no_tenant_when_from_headers_then_raise(self, request):
         request.headers = {}
 
         assert_that(calling(Tenant.from_headers), raises(InvalidTenant))
 
-    @patch('xivo.tenant_helpers.request', spec={})
+    @patch('xivo.flask.headers.request', spec={})
     def test_given_tenant_when_from_headers_then_return_tenant(self, request):
         tenant = 'tenant'
         request.headers = {'Wazo-Tenant': tenant}


### PR DESCRIPTION
why: will remove a query to wazo-auth when Wazo-Tenant is present