### PR TITLE
add tenant_uuid to Unauthorized exception

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -82,7 +82,11 @@ class AuthVerifierHelpers:
         except exceptions.InvalidTokenException:
             raise InvalidTokenAPIException(token_uuid, required_acl)
         except exceptions.MissingPermissionsTokenException:
-            raise MissingPermissionsTokenAPIException(token_uuid, required_acl)
+            raise MissingPermissionsTokenAPIException(
+                token_uuid,
+                required_acl,
+                tenant_uuid,
+            )
         except requests.RequestException as error:
             raise AuthServerUnreachable(auth_client.host, auth_client.port, error)
 

--- a/xivo/http_exceptions.py
+++ b/xivo/http_exceptions.py
@@ -35,10 +35,18 @@ class InvalidTokenAPIException(rest_api_helpers.APIException):
 
 
 class MissingPermissionsTokenAPIException(rest_api_helpers.APIException):
-    def __init__(self, token: str, required_access: str | None = None) -> None:
-        details = {'invalid_token': token, 'reason': 'missing_permission'}
-        if required_access:
-            details['required_access'] = required_access
+    def __init__(
+        self,
+        token: str,
+        required_access: str | None,
+        tenant_uuid: str | None,
+    ) -> None:
+        details = {
+            'invalid_token': token,
+            'reason': 'missing_permission_or_invalid_tenant',
+            'required_access': required_access,
+            'tenant_uuid': tenant_uuid,
+        }
         super().__init__(
             status_code=401,
             message='Unauthorized',


### PR DESCRIPTION
why: we are now verifying tenant and scope at the same time, so both can
trigger a 403