### PR TITLE
WAZO-3847: Adding py.typed sentinel file to support type checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2007-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import find_packages, setup
@@ -12,4 +12,5 @@ setup(
     author_email='dev@wazo.community',
     url='http://wazo.community',
     packages=find_packages(),
+    package_data={'xivo': ['py.typed']},
 )


### PR DESCRIPTION
https://typing.readthedocs.io/en/latest/guides/libraries.html#marking-a-package-as-providing-type-information
a sentinel file must be present and distributed in package to signal to type checkers that the library provides type information that can be used; otherwise imports from this library are considered untyped.
