### PR TITLE
Adding py.typed sentinel file to support type checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2007-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import find_packages, setup
@@ -12,4 +12,5 @@ setup(
     author_email='dev@wazo.community',
     url='http://wazo.community',
     packages=find_packages(),
+    package_data={'xivo': ['py.typed']},
 )

--- a/xivo/chain_map.py
+++ b/xivo/chain_map.py
@@ -1,19 +1,21 @@
-# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections import UserDict
+from collections.abc import Mapping
 from copy import copy
+from typing import Any
 
 
 class ChainMap(UserDict):
-    def __init__(self, *dicts: dict) -> None:
+    def __init__(self, *dicts: Mapping[str, Any]) -> None:
         self.data = {}
         for d in dicts:
             self.data = self._deep_update(self.data, d)
 
-    def _deep_update(self, original: dict, new: dict) -> dict:
+    def _deep_update(self, original: dict, new: Mapping[str, Any]) -> dict:
         updated = copy(original)
 
         for key, value in new.items():
@@ -26,7 +28,7 @@ class ChainMap(UserDict):
 
 
 class AccumulatingListChainMap(ChainMap):
-    def _deep_update(self, original: dict, new: dict) -> dict:
+    def _deep_update(self, original: dict, new: Mapping[str, Any]) -> dict:
         updated = copy(original)
 
         for key, value in new.items():

--- a/xivo/config_helper.py
+++ b/xivo/config_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from collections.abc import Generator
+from collections.abc import Generator, Mapping, MutableMapping
 from functools import partial
 from logging import Logger
 from typing import Any
@@ -111,7 +111,7 @@ class ConfigParser:
 
     def read_config_file_hierarchy(
         self,
-        original_config: dict[str, Any],
+        original_config: Mapping[str, Any],
         config_file_key: str = 'config_file',
         extra_config_dir_key: str = 'extra_config_files',
     ) -> ChainMap:
@@ -138,7 +138,7 @@ class ConfigParser:
         return ChainMap(*configs)
 
     def read_config_file_hierarchy_accumulating_list(
-        self, original_config: dict[str, Any]
+        self, original_config: Mapping[str, Any]
     ) -> AccumulatingListChainMap:
         main_config_filename = original_config['config_file']
         main_config = self.parse_config_file(main_config_filename)
@@ -164,7 +164,7 @@ def get_xivo_uuid(logger: Logger) -> str:
     return xivo_uuid
 
 
-def set_xivo_uuid(config: dict[str, Any], logger: Logger) -> None:
+def set_xivo_uuid(config: MutableMapping[str, Any], logger: Logger) -> None:
     config['uuid'] = get_xivo_uuid(logger)
 
 

--- a/xivo/consul_helpers.py
+++ b/xivo/consul_helpers.py
@@ -1,11 +1,11 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from types import TracebackType
 from typing import Any, TypedDict, TypeVar
 from uuid import uuid4
@@ -313,7 +313,7 @@ class NotifyingRegisterer(Registerer):
 
 
 class ServiceFinder:
-    def __init__(self, consul_config: dict[str, Any]) -> None:
+    def __init__(self, consul_config: Mapping[str, Any]) -> None:
         self._dc_url = '{scheme}://{host}:{port}/v1/catalog/datacenters'.format(
             **consul_config
         )

--- a/xivo/http_exceptions.py
+++ b/xivo/http_exceptions.py
@@ -1,9 +1,7 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
-
-import requests
 
 from xivo import rest_api_helpers
 
@@ -57,9 +55,7 @@ class MissingPermissionsTokenAPIException(rest_api_helpers.APIException):
 
 
 class AuthServerUnreachable(rest_api_helpers.APIException):
-    def __init__(
-        self, host: str | None, port: int | None, error: requests.RequestException
-    ) -> None:
+    def __init__(self, host: str | None, port: int | None, error: Exception) -> None:
         super().__init__(
             status_code=503,
             message='Authentication server unreachable',

--- a/xivo/http_helpers.py
+++ b/xivo/http_helpers.py
@@ -7,7 +7,7 @@ import json
 import re
 import time
 import uuid
-from collections.abc import Iterable
+from collections.abc import Iterable, MutableMapping
 from json.decoder import JSONDecodeError
 from logging import Logger
 from typing import TYPE_CHECKING, Any
@@ -43,7 +43,7 @@ class ReverseProxied:
         return self.app(environ, start_response)
 
 
-def reverse_proxy_fix_api_spec(api_spec: dict[str, Any]) -> None:
+def reverse_proxy_fix_api_spec(api_spec: MutableMapping[str, Any]) -> None:
     prefix = request.headers.get('X-Script-Name')
     if prefix:
         api_spec['schemes'] = ['https']

--- a/xivo/token_renewer.py
+++ b/xivo/token_renewer.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -7,7 +7,7 @@ import itertools
 import logging
 import threading
 import types
-from collections.abc import Callable, Collection
+from collections.abc import Callable
 from typing import TYPE_CHECKING, TypedDict, TypeVar
 
 import requests
@@ -18,7 +18,9 @@ if TYPE_CHECKING:
     from wazo_auth_client.client import AuthClient
 
 
-Callback = Callable[[Collection[str]], None]
+# a token-change callback receives token['token'] while a details callback
+# receives the full token dict, so the argument shape varies by subscription.
+Callback = Callable[..., None]
 
 
 class CallbackDict(TypedDict):

--- a/xivo/wsgi.py
+++ b/xivo/wsgi.py
@@ -1,9 +1,11 @@
-# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 import os
 import time
+from collections.abc import Callable
+from typing import Any
 
 from cheroot.wsgi import PathInfoDispatcher, Server
 
@@ -53,4 +55,6 @@ class PatchedWSGIServer(Server):  # noqa
 
 
 WSGIServer = PatchedWSGIServer
-WSGIPathInfoDispatcher = PathInfoDispatcher
+# cheroot ships no type information, so annotate the re-export to give callers a
+# typed callable instead of an untyped-call error.
+WSGIPathInfoDispatcher: Callable[..., Any] = PathInfoDispatcher


### PR DESCRIPTION
https://typing.readthedocs.io/en/latest/guides/libraries.html#marking-a-package-as-providing-type-information a sentinel file must be present and distributed in package to signal to type checkers that the library provides type information that can be used; otherwise imports from this library are considered untyped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are packaging metadata and static typing only; runtime behavior is unchanged aside from broader exception typing on AuthServerUnreachable, which remains compatible with existing RequestException callers.
> 
> **Overview**
> Marks the **xivo** package as type-checked by distributing **`py.typed`** via `setup.py` `package_data`, so downstream projects treat imports as typed instead of `Any`.
> 
> Alongside that, several public APIs are annotated more precisely: config/`ChainMap` helpers accept **`Mapping`** / **`MutableMapping`** instead of plain `dict`, **`ServiceFinder`** takes a read-only consul config mapping, and **`reverse_proxy_fix_api_spec`** / **`set_xivo_uuid`** reflect mutability where values are written in place. **`AuthServerUnreachable`** now documents its `error` argument as **`Exception`** (drops the unused `requests` import). **`TokenRenewer`** callbacks are typed as **`Callable[..., None]`** with a short note that payload shape depends on subscription. **`WSGIPathInfoDispatcher`** gets an explicit annotation because cheroot ships without stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c23d5d69e0fabc3d0e861fcd37f7c6d3d2be20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->