### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ itsdangerous==1.1.0  # from flask
 jinja2==3.0.3  # from flask
 markupsafe==2.0.1 # from flask
 werkzeug==1.0.1 # from flask
-marshmallow==3.10.0
+marshmallow==3.18.0
 netifaces==0.10.9
 python-consul==1.1.0
 pyyaml==5.3.1

--- a/xivo/mallow_helpers.py
+++ b/xivo/mallow_helpers.py
@@ -43,9 +43,9 @@ class ListSchema(marshmallow.Schema):
 
     direction = fields.String(validate=validate.OneOf(['asc', 'desc']))
     order = fields.String()
-    limit = fields.Integer(validate=validate.Range(min=0), missing=None)
-    offset = fields.Integer(validate=validate.Range(min=0), missing=0)
-    search = fields.String(missing=None)
+    limit = fields.Integer(validate=validate.Range(min=0), load_default=None)
+    offset = fields.Integer(validate=validate.Range(min=0), load_default=0)
+    search = fields.String(load_default=None)
 
     class Meta:
         unknown = marshmallow.EXCLUDE


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade