### PR TITLE
auth_verifier: add reserved word 'edit' to 'update'

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -161,6 +161,7 @@ class AccessCheck:
             access_regex,
             ReservedWord('me', auth_id),
             ReservedWord('my_session', session_id),
+            ReservedWord('edit', 'update'),  # Compatibility for deprecated suffix
         )
         return re.compile(f'^{access_regex}$')
 

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -381,5 +381,15 @@ class TestAccessCheck:
         assert_that(check.matches_required_access('foo.my_session'))
         assert_that(
             check.matches_required_access('foo.another-session-uuid'),
+            equal_to(False),
+        )
+
+    def test_matches_edit(self):
+        check = AccessCheck('123', 'session-uuid', ['foo.edit'])
+
+        assert_that(check.matches_required_access('foo.edit'))
+        assert_that(check.matches_required_access('foo.update'))
+        assert_that(
+            check.matches_required_access('foo.edit.update'),
             equal_to(False),
         )


### PR DESCRIPTION
why: wazo-auth suffix was not consistant with other services and
documentation. Instead of create a breaking change, we will allow edit
and update for ACL for some time