### PR TITLE
add required_acl to flask's g object

### DIFF
--- a/xivo/flask/auth_verifier.py
+++ b/xivo/flask/auth_verifier.py
@@ -43,7 +43,10 @@ class AuthVerifierFlask:
                 tenant_uuid,
             )
 
+            # NOTE: Used to efficiently retrieve endpoint's required ACL directly
+            #       in request context, useful for hooks and plugins
             g.verified_acl = required_acl
+
             g.verified_tenant_uuid = tenant_uuid
 
             return func(*args, **kwargs)

--- a/xivo/flask/auth_verifier.py
+++ b/xivo/flask/auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -43,6 +43,7 @@ class AuthVerifierFlask:
                 tenant_uuid,
             )
 
+            g.verified_acl = required_acl
             g.verified_tenant_uuid = tenant_uuid
 
             return func(*args, **kwargs)


### PR DESCRIPTION
why:
- makes retrieving the required_acl easier from within the request context