### PR TITLE
WP-2120-remove-pkg-resources

### DIFF
--- a/xivo/rest_api_helpers.py
+++ b/xivo/rest_api_helpers.py
@@ -1,16 +1,17 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
+import importlib.resources
 import logging
 import time
 from collections.abc import Callable, Generator
 from functools import wraps
+from importlib.metadata import entry_points
 from typing import Any, TypeVar
 
 import yaml
-from pkg_resources import iter_entry_points, resource_string
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +59,16 @@ def handle_api_exception(
 def load_all_api_specs(
     entry_point_group: str, spec_filename: str
 ) -> Generator[dict[str, Any]]:
-    for module in iter_entry_points(group=entry_point_group):
+    for ep in entry_points(group=entry_point_group):
+        package_name = ep.value.split(':')[0].rsplit('.', 1)[0]
         try:
-            spec = yaml.safe_load(resource_string(module.module_name, spec_filename))
+            spec = yaml.safe_load(
+                importlib.resources.files(package_name)
+                .joinpath(spec_filename)
+                .read_bytes()
+            )
             yield spec
         except OSError:
-            logger.debug('API spec for module "%s" does not exist', module.module_name)
+            logger.debug('API spec for package "%s" does not exist', package_name)
         except ImportError as e:
-            logger.warning('Could not load module %s: %s', module.module_name, e)
+            logger.warning('Could not load package %s: %s', package_name, e)

--- a/xivo/tests/test_rest_api_helpers.py
+++ b/xivo/tests/test_rest_api_helpers.py
@@ -1,13 +1,15 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from importlib.metadata import EntryPoint
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import create_autospec, patch
 from unittest.mock import sentinel as s
 
 from hamcrest import (
     assert_that,
     contains_exactly,
+    empty,
     equal_to,
     has_entries,
     instance_of,
@@ -15,7 +17,7 @@ from hamcrest import (
     raises,
 )
 
-from ..rest_api_helpers import APIException, handle_api_exception
+from ..rest_api_helpers import APIException, handle_api_exception, load_all_api_specs
 
 
 class TestRestApiHelpers(TestCase):
@@ -101,3 +103,73 @@ class TestRestApiHelpers(TestCase):
         decorated()
 
         assert_that(logger.error.called, is_(True))
+
+
+def _make_entry_point(value):
+    return create_autospec(spec=EntryPoint, value=value)
+
+
+@patch('xivo.rest_api_helpers.importlib.resources.files')
+@patch('xivo.rest_api_helpers.entry_points')
+class TestLoadAllApiSpecs(TestCase):
+    def _set_spec_content(self, resources_files, content):
+        resources_files.return_value.joinpath.return_value.read_bytes.return_value = (
+            content
+        )
+
+    def test_yields_parsed_specs(self, entry_points, resources_files):
+        entry_points.return_value = [
+            _make_entry_point('my_pkg.plugins.foo.http:ViewPlugin')
+        ]
+        self._set_spec_content(resources_files, b'info:\n  title: test')
+
+        result = list(load_all_api_specs('my_group', 'api.yml'))
+
+        assert_that(
+            result,
+            contains_exactly(has_entries(info=has_entries(title='test'))),
+        )
+
+    def test_package_name_derivation(self, entry_points, resources_files):
+        cases = [
+            ('wazo_dird.plugins.api.http:ApiViewPlugin', 'wazo_dird.plugins.api'),
+            ('my_pkg.module:Class', 'my_pkg'),
+            ('a.b.c.d.e:F', 'a.b.c.d'),
+        ]
+        for ep_value, expected_package in cases:
+            resources_files.reset_mock()
+            entry_points.return_value = [_make_entry_point(ep_value)]
+            self._set_spec_content(resources_files, b'info: {}')
+
+            list(load_all_api_specs('group', 'api.yml'))
+
+            resources_files.assert_called_with(expected_package)
+
+    def test_skips_missing_spec_file(self, entry_points, resources_files):
+        entry_points.return_value = [
+            _make_entry_point('my_pkg.plugins.foo.http:Plugin')
+        ]
+        resources_files.return_value.joinpath.return_value.read_bytes.side_effect = (
+            OSError('file not found')
+        )
+
+        result = list(load_all_api_specs('group', 'api.yml'))
+
+        assert_that(result, is_(empty()))
+
+    def test_skips_unloadable_package(self, entry_points, resources_files):
+        entry_points.return_value = [
+            _make_entry_point('bad_pkg.plugins.foo.http:Plugin')
+        ]
+        resources_files.side_effect = ImportError('no module')
+
+        result = list(load_all_api_specs('group', 'api.yml'))
+
+        assert_that(result, is_(empty()))
+
+    def test_empty_group(self, entry_points, resources_files):
+        entry_points.return_value = []
+
+        result = list(load_all_api_specs('group', 'api.yml'))
+
+        assert_that(result, is_(empty()))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to how API spec files are discovered/read via entry points and is covered by new unit tests; no auth/data-path logic is affected.
> 
> **Overview**
> Removes the `pkg_resources` dependency for API spec discovery/loading by switching `load_all_api_specs` to `importlib.metadata.entry_points` and `importlib.resources` to read spec bytes from the derived package.
> 
> Adds a dedicated test suite for `load_all_api_specs`, covering successful YAML parsing, package-name derivation from entry point values, and graceful skipping for missing spec files, unloadable packages, and empty entry point groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72c88118603236e0a83fb40cc33c0c013d8cd7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->