### PR TITLE
WP-1987-sort-insensitive

### DIFF
--- a/xivo/mallow_helpers.py
+++ b/xivo/mallow_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -41,6 +41,7 @@ class ListSchema(marshmallow.Schema):
     sort_columns: list[str] = []
     searchable_columns: list[str] = []
     default_direction: Literal['asc', 'desc'] = 'asc'
+    sort_insensitive_columns: list[str] = []
 
     direction = fields.String(validate=validate.OneOf(['asc', 'desc']))
     order = fields.String()
@@ -76,6 +77,13 @@ class ListSchema(marshmallow.Schema):
             if key in self.searchable_columns:
                 data.setdefault(key, value)
 
+        return data
+
+    @marshmallow.post_load()
+    def add_order_insensitive_field(
+        self, data: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        data['order_insensitive'] = data['order'] in self.sort_insensitive_columns
         return data
 
 

--- a/xivo/tests/test_mallow_helpers.py
+++ b/xivo/tests/test_mallow_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -99,3 +99,35 @@ class TestListSchema(unittest.TestCase):
             result,
             has_entries(direction='asc', order=None, limit=None, offset=0, search=None),
         )
+
+    def test_order_insensitive_default_is_false(self):
+        result = ListSchema().load({})
+
+        assert_that(result, has_entries(order_insensitive=False))
+
+    def test_order_insensitive_when_order_in_sort_insensitive_columns(self):
+        class Schema(ListSchema):
+            sort_columns = ['name', 'email']
+            sort_insensitive_columns = ['name']
+
+        result = Schema().load({'order': 'name'})
+
+        assert_that(result, has_entries(order_insensitive=True))
+
+    def test_order_insensitive_when_order_not_in_sort_insensitive_columns(self):
+        class Schema(ListSchema):
+            sort_columns = ['name', 'email']
+            sort_insensitive_columns = ['name']
+
+        result = Schema().load({'order': 'email'})
+
+        assert_that(result, has_entries(order_insensitive=False))
+
+    def test_order_insensitive_when_sort_insensitive_columns_is_empty(self):
+        class Schema(ListSchema):
+            sort_columns = ['name']
+            sort_insensitive_columns = []
+
+        result = Schema().load({'order': 'name'})
+
+        assert_that(result, has_entries(order_insensitive=False))


### PR DESCRIPTION
why: this define which columns should be ordered case insensitively or
not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `order_insensitive` field to `ListSchema` load results, which changes the shape of parsed list-query params and could affect downstream consumers relying on exact keys.
> 
> **Overview**
> `ListSchema` now supports declaring `sort_insensitive_columns` and, on load, emits a new boolean `order_insensitive` indicating whether the requested `order` column should be sorted case-insensitively.
> 
> Tests were extended to cover default behavior and the true/false cases when `order` is (or isn’t) included in `sort_insensitive_columns`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd25781813eb39f0379845c0c0031b7b10ac2a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->