### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: myservice
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the integration-test `docker-compose.yml` to use a pinned `rabbitmq:3` image, reducing variability but potentially surfacing version-specific behavior.
> 
> **Overview**
> Pins the integration test RabbitMQ container from `rabbitmq` (latest) to `rabbitmq:3` in `integration_tests/assets/docker-compose.yml` to make the test environment deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e17793e461a583c64ddb7160f2ec6bb048dd0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->