### PR TITLE
http_exceptions: insufficient permissions use 403 status code

### DIFF
--- a/xivo/http_exceptions.py
+++ b/xivo/http_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -49,9 +49,9 @@ class MissingPermissionsTokenAPIException(rest_api_helpers.APIException):
             'tenant_uuid': tenant_uuid,
         }
         super().__init__(
-            status_code=401,
-            message='Unauthorized',
-            error_id='unauthorized',
+            status_code=403,
+            message='Forbidden',
+            error_id='forbidden',
             details=details,
         )
 

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -65,6 +65,40 @@ class TestAuthVerifierHelpers(unittest.TestCase):
                 required_acl,
                 tenant_uuid,
             )
+
+    def test_validate_token_with_no_acl_permission_raises_403(self):
+        mock_client = Mock()
+        mock_client.token.check.side_effect = MissingPermissionsTokenException
+        token_uuid = s.token
+        tenant_uuid = s.tenant
+        required_acl = s.acl
+
+        with pytest.raises(MissingPermissionsTokenAPIException) as exc_info:
+            self.helpers.validate_token(
+                mock_client,
+                token_uuid,
+                required_acl,
+                tenant_uuid,
+            )
+
+        assert exc_info.value.status_code == 403
+
+    def test_validate_invalid_token_raises_401(self):
+        mock_client = Mock()
+        mock_client.token.check.side_effect = InvalidTokenException
+        token_uuid = s.token
+        tenant_uuid = s.tenant
+        required_acl = s.acl
+
+        with pytest.raises(InvalidTokenAPIException) as exc_info:
+            self.helpers.validate_token(
+                mock_client,
+                token_uuid,
+                required_acl,
+                tenant_uuid,
+            )
+
+        assert exc_info.value.status_code == 401
 
     def test_validate_token_raise_unreachable(self):
         mock_client = Mock()


### PR DESCRIPTION
NOTE: before merging this, 

- [ ] evaluate if we're okay exposing permission errors as 403 (already visible in response body)
- [ ] evaluate impact on each impacted wazo service (minimally, create PR with Depends-On on this one to find what breaks in tests)

See wazo-confd https://github.com/wazo-platform/wazo-confd/pull/565 for example of impact and changes required.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only the HTTP status/message for insufficient-permission tokens and tightens unit test coverage; main risk is behavior change for clients that previously expected `401` in this case.
> 
> **Overview**
> Updates `MissingPermissionsTokenAPIException` to respond with **`403 Forbidden`** (and `error_id='forbidden'`) rather than `401 Unauthorized` when token validation fails due to missing permissions or invalid tenant.
> 
> Extends `test_auth_verifier` to assert the new 403 behavior for missing permissions and to explicitly assert `401` for invalid tokens, clarifying expected status codes per failure mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5318d23f2fb959eaec4198a5d0a52e8d05dad35f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->