### PR TITLE
ITEM-378 add request id, timezone timestamp in logs

### DIFF
--- a/xivo/http_helpers.py
+++ b/xivo/http_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import re
 import time
+import uuid
 from collections.abc import Iterable
 from json.decoder import JSONDecodeError
 from logging import Logger
@@ -127,7 +128,7 @@ def _log_request(
     url: str, response: Response, hidden_fields: list[str] | None = None
 ) -> None:
     current_app.logger.info(
-        'response to %s%s: %s %s %s',
+        'response to %s%s: %s %s %s [request_id=%s]',
         request.remote_addr,
         (
             f' in {time.time() - g.request_time:.2f}s'
@@ -137,6 +138,7 @@ def _log_request(
         request.method,
         url,
         response.status_code,
+        getattr(g, 'request_id', '-'),
     )
     if response.headers.get('Content-Type') not in PRINTABLE_CONTENT_TYPES:
         content_type = response.headers.get('Content-Type')
@@ -157,12 +159,21 @@ def log_before_request(hidden_fields: list[str] | None = None) -> None:
         'headers': LazyHeaderFormatter(request.headers),
     }
 
+    _trace_id = (
+        (request.headers.get('Wazo-Trace-ID') or '').replace('\r', '').replace('\n', '')
+    )
+    g.request_id = _trace_id or str(uuid.uuid4())
+
     if request.data and request.headers.get('Content-Type') in PRINTABLE_CONTENT_TYPES:
         params['data'] = BodyFormatter(request.data, hidden_fields)
-        fmt = "request: %(method)s %(url)s %(headers)s with data %(data)s"
+        fmt = (
+            "request: %(method)s %(url)s %(headers)s with data %(data)s"
+            "[request_id=%(request_id)s]"
+        )
     else:
-        fmt = "request: %(method)s %(url)s %(headers)s"
+        fmt = "request: %(method)s %(url)s %(headers)s [request_id=%(request_id)s]"
 
+    params['request_id'] = g.request_id
     current_app.logger.info(fmt, params)
     g.request_time = time.time()
 

--- a/xivo/tests/test_http_helpers.py
+++ b/xivo/tests/test_http_helpers.py
@@ -1,15 +1,16 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 import unittest
 from unittest.mock import ANY, Mock, patch
 
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, matches_regexp
 
 from xivo.http_helpers import (
     BodyFormatter,
     LazyHeaderFormatter,
+    log_before_request,
     log_request,
     log_request_hide_token,
 )
@@ -41,6 +42,7 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.method,
                 mock_request.url,
                 200,
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
@@ -64,6 +66,7 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.method,
                 expected_url,
                 200,
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
@@ -86,6 +89,86 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.method,
                 mock_request.url,
                 200,
+                '-',
+            )
+
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_before_request_uses_wazo_trace_id_as_request_id(self, g):
+        wazo_trace_id = 'a06f7f341db5b95a-AMS'
+        mock_request = Mock(data=b'', method='GET')
+        mock_request.headers.get.side_effect = (
+            lambda k, *a: wazo_trace_id if k == 'Wazo-Trace-ID' else None
+        )
+        mock_request.url = '/foo/bar'
+
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_before_request()
+
+            assert_that(g.request_id, equal_to(wazo_trace_id))
+            params = mock_current_app.logger.info.call_args[0][-1]
+            assert_that(params['request_id'], equal_to(wazo_trace_id))
+
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_before_request_generates_uuid_when_no_cf_ray(self, g):
+        mock_request = Mock(data=b'', method='GET')
+        mock_request.headers.get = Mock(return_value=None)
+        mock_request.url = '/foo/bar'
+
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_before_request()
+
+            assert_that(
+                g.request_id,
+                matches_regexp(
+                    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+                ),
+            )
+            params = mock_current_app.logger.info.call_args[0][-1]
+            assert_that(params['request_id'], equal_to(g.request_id))
+
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_before_request_sanitizes_newlines_in_wazo_trace_id(self, g):
+        mock_request = Mock(data=b'', method='GET')
+        mock_request.headers.get.side_effect = (
+            lambda k, *a: 'trace-id\nforged log line' if k == 'Wazo-Trace-ID' else None
+        )
+        mock_request.url = '/foo/bar'
+
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()),
+        ):
+            log_before_request()
+
+            assert_that(g.request_id, equal_to('trace-idforged log line'))
+
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_request_includes_request_id(self, g):
+        g.request_id = 'test-id-123'
+        mock_request = Mock()
+        mock_request.url = '/foo/bar'
+        response = Mock(data=None, status_code=200)
+
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_request(response)
+
+            mock_current_app.logger.info.assert_called_once_with(
+                ANY,
+                mock_request.remote_addr,
+                ANY,
+                mock_request.method,
+                mock_request.url,
+                200,
+                'test-id-123',
             )
 
 

--- a/xivo/tests/test_xivo_logging.py
+++ b/xivo/tests/test_xivo_logging.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,6 +19,7 @@ from hamcrest import (
 )
 
 from xivo.xivo_logging import (
+    DEFAULT_LOG_DATEFMT,
     DEFAULT_LOG_FORMAT,
     DEFAULT_LOG_LEVEL,
     excepthook,
@@ -92,15 +93,19 @@ class TestLogging(TestCase):
 
         setup_logging(log_file)
 
-        logging.Formatter.assert_called_once_with(DEFAULT_LOG_FORMAT)
+        logging.Formatter.assert_called_once_with(
+            DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATEFMT
+        )
 
     def test_setup_logging_with_format_then_log_format_is_not_default(self, logging):
         log_file = Mock()
-        log_format = Mock()
+        log_format = '%(message)s'
 
         setup_logging(log_file, log_format=log_format)
 
-        logging.Formatter.assert_called_once_with(log_format)
+        logging.Formatter.assert_called_once_with(
+            log_format, datefmt=DEFAULT_LOG_DATEFMT
+        )
 
     def test_that_setup_logging_adds_excepthook(self, logging):
         log_file = Mock()

--- a/xivo/xivo_logging.py
+++ b/xivo/xivo_logging.py
@@ -9,7 +9,8 @@ import types
 from collections.abc import Callable, Sequence
 
 DEFAULT_LOG_FORMAT = (
-    '%(asctime)s [%(process)d] [%(thread)d] (%(levelname)s) (%(name)s): %(message)s'
+    '%(asctime)s [pid %(process)d] [tid %(thread)d] (%(levelname)s)'
+    ' (%(name)s): %(message)s'
 )
 DEFAULT_LOG_DATEFMT = '%Y-%m-%d %H:%M:%S %Z'
 DEFAULT_LOG_LEVEL = logging.INFO

--- a/xivo/xivo_logging.py
+++ b/xivo/xivo_logging.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -8,7 +8,10 @@ import sys
 import types
 from collections.abc import Callable, Sequence
 
-DEFAULT_LOG_FORMAT = '%(asctime)s [%(process)d] (%(levelname)s) (%(name)s): %(message)s'
+DEFAULT_LOG_FORMAT = (
+    '%(asctime)s [%(process)d] [%(thread)d] (%(levelname)s) (%(name)s): %(message)s'
+)
+DEFAULT_LOG_DATEFMT = '%Y-%m-%d %H:%M:%S %Z'
 DEFAULT_LOG_LEVEL = logging.INFO
 
 
@@ -52,6 +55,7 @@ def setup_logging(
     debug: bool = False,
     log_level: int = DEFAULT_LOG_LEVEL,
     log_format: str = DEFAULT_LOG_FORMAT,
+    log_datefmt: str = DEFAULT_LOG_DATEFMT,
 ) -> None:
     """
     logger.*  ------------------------ v
@@ -61,7 +65,7 @@ def setup_logging(
     """
     root_logger = logging.getLogger()
 
-    formatter = logging.Formatter(log_format)
+    formatter = logging.Formatter(log_format, datefmt=log_datefmt)
 
     handler = logging.FileHandler(log_file)
     handler.setFormatter(formatter)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only changes to log format and request metadata; no auth or business logic, though default log line shape changes may affect log parsers.
> 
> **Overview**
> Improves **correlation and readability** of HTTP and application logs.
> 
> **HTTP request tracing:** `log_before_request` now sets `g.request_id` from the sanitized `Wazo-Trace-ID` header when present, otherwise a new UUID4. That id is included on both incoming request and outgoing response log lines (`[request_id=...]`). Newlines/carriage returns are stripped from trace ids to reduce log-forging risk.
> 
> **Default logging layout:** `setup_logging` uses an expanded default format with explicit `pid`/`tid` labels and a new `DEFAULT_LOG_DATEFMT` (`%Y-%m-%d %H:%M:%S %Z`) so timestamps show the timezone. Custom `log_format` still gets the default date format unless callers override `log_datefmt`.
> 
> Tests cover trace-id vs UUID fallback, trace-id sanitization, request_id on response logs, and formatter `datefmt` wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b750ce8b3382fb3597ee249a09cc04ac26dd7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->