### PR TITLE
ITEM-418 feat(traceparent-logging): implement w3c trace context propagation

### DIFF
--- a/xivo/http_helpers.py
+++ b/xivo/http_helpers.py
@@ -210,7 +210,7 @@ def log_before_request(hidden_fields: list[str] | None = None) -> None:
         g.trace_id = trace_context.trace_id
         g.parent_id = trace_context.parent_id
     else:
-        g.trace_id = request.headers.get('Wazo-Trace-ID') or _generate_trace_id()
+        g.trace_id = _generate_trace_id()
         g.parent_id = None
 
     params['span_id'] = g.span_id

--- a/xivo/http_helpers.py
+++ b/xivo/http_helpers.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import json
 import re
+import secrets
 import time
-import uuid
 from collections.abc import Iterable, MutableMapping
 from json.decoder import JSONDecodeError
 from logging import Logger
@@ -124,12 +124,48 @@ class LazyHeaderFormatter:
         return dict(headers)
 
 
+_TRACEPARENT_REGEX = re.compile(
+    r'^(?P<version>[0-9a-f]{2})'
+    r'-(?P<trace_id>[0-9a-f]{32})'
+    r'-(?P<parent_id>[0-9a-f]{16})'
+    r'-(?P<flags>[0-9a-f]{2})$',
+    re.IGNORECASE,
+)
+
+
+def _parse_traceparent(value: str | None) -> str | None:
+    """Extract the W3C trace-id from a `traceparent` header value.
+
+    Returns the 32-hex-char trace-id (lowercased) or None if the header is
+    absent or invalid per https://www.w3.org/TR/trace-context/.
+    """
+    if not value:
+        return None
+    match = _TRACEPARENT_REGEX.match(value)
+    if not match:
+        return None
+    if match.group('version') == 'ff':
+        return None
+    trace_id = match.group('trace_id').lower()
+    parent_id = match.group('parent_id').lower()
+    if trace_id == '0' * 32 or parent_id == '0' * 16:
+        return None
+    return trace_id
+
+
+def _generate_trace_id() -> str:
+    return secrets.token_hex(16)
+
+
+def _generate_request_id() -> str:
+    return secrets.token_hex(8)
+
+
 def _log_request(
     url: str, response: Response, hidden_fields: list[str] | None = None
 ) -> None:
-    trace_id = getattr(g, 'trace_id', None)
     current_app.logger.info(
-        'response to %s%s: %s %s %s [request_id=%s]%s',
+        'response to %s%s: %s %s %s [request_id=%s] [trace_id=%s]',
         request.remote_addr,
         (
             f' in {time.time() - g.request_time:.2f}s'
@@ -140,7 +176,7 @@ def _log_request(
         url,
         response.status_code,
         getattr(g, 'request_id', '-'),
-        f' [trace_id={trace_id}]' if trace_id else '',
+        getattr(g, 'trace_id', '-'),
     )
     if response.headers.get('Content-Type') not in PRINTABLE_CONTENT_TYPES:
         content_type = response.headers.get('Content-Type')
@@ -161,24 +197,27 @@ def log_before_request(hidden_fields: list[str] | None = None) -> None:
         'headers': LazyHeaderFormatter(request.headers),
     }
 
-    g.request_id = str(uuid.uuid4())
-    g.trace_id = request.headers.get('Wazo-Trace-ID') or None
+    g.request_id = _generate_request_id()
+    g.trace_id = (
+        _parse_traceparent(request.headers.get('traceparent'))
+        or request.headers.get('Wazo-Trace-ID')
+        or _generate_trace_id()
+    )
 
     params['request_id'] = g.request_id
-    if g.trace_id:
-        params['trace_id'] = g.trace_id
+    params['trace_id'] = g.trace_id
 
     if request.data and request.headers.get('Content-Type') in PRINTABLE_CONTENT_TYPES:
         params['data'] = BodyFormatter(request.data, hidden_fields)
         fmt = (
             "request: %(method)s %(url)s %(headers)s with data %(data)s"
-            " [request_id=%(request_id)s]"
+            " [request_id=%(request_id)s] [trace_id=%(trace_id)s]"
         )
     else:
-        fmt = "request: %(method)s %(url)s %(headers)s [request_id=%(request_id)s]"
-
-    if g.trace_id:
-        fmt += ' [trace_id=%(trace_id)s]'
+        fmt = (
+            "request: %(method)s %(url)s %(headers)s"
+            " [request_id=%(request_id)s] [trace_id=%(trace_id)s]"
+        )
 
     current_app.logger.info(fmt, params)
     g.request_time = time.time()

--- a/xivo/http_helpers.py
+++ b/xivo/http_helpers.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Iterable, MutableMapping
 from json.decoder import JSONDecodeError
 from logging import Logger
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import unquote
 
 from cheroot.ssl.builtin import BuiltinSSLAdapter
@@ -133,31 +133,37 @@ _TRACEPARENT_REGEX = re.compile(
 )
 
 
-def _parse_traceparent(value: str | None) -> str | None:
-    """Extract the W3C trace-id from a `traceparent` header value.
+class TraceContext(NamedTuple):
+    trace_id: str
+    parent_id: str
 
-    Returns the 32-hex-char trace-id (lowercased) or None if the header is
-    absent or invalid per https://www.w3.org/TR/trace-context/.
+
+def _parse_traceparent(value: str | None) -> TraceContext | None:
+    """Extract the W3C trace context from a `traceparent` header value.
+
+    Returns the (trace-id, parent-id) pair (lowercased hex) or None if the
+    header is absent or invalid per https://www.w3.org/TR/trace-context/.
+    The parent-id is the span-id of the calling service.
     """
     if not value:
         return None
     match = _TRACEPARENT_REGEX.match(value)
     if not match:
         return None
-    if match.group('version') == 'ff':
+    if match.group('version').lower() == 'ff':
         return None
     trace_id = match.group('trace_id').lower()
     parent_id = match.group('parent_id').lower()
     if trace_id == '0' * 32 or parent_id == '0' * 16:
         return None
-    return trace_id
+    return TraceContext(trace_id, parent_id)
 
 
 def _generate_trace_id() -> str:
     return secrets.token_hex(16)
 
 
-def _generate_request_id() -> str:
+def _generate_span_id() -> str:
     return secrets.token_hex(8)
 
 
@@ -165,7 +171,7 @@ def _log_request(
     url: str, response: Response, hidden_fields: list[str] | None = None
 ) -> None:
     current_app.logger.info(
-        'response to %s%s: %s %s %s [request_id=%s] [trace_id=%s]',
+        'response to %s%s: %s %s %s [span_id=%s parent_id=%s trace_id=%s]',
         request.remote_addr,
         (
             f' in {time.time() - g.request_time:.2f}s'
@@ -175,7 +181,8 @@ def _log_request(
         request.method,
         url,
         response.status_code,
-        getattr(g, 'request_id', '-'),
+        getattr(g, 'span_id', '-'),
+        getattr(g, 'parent_id', None) or '-',
         getattr(g, 'trace_id', '-'),
     )
     if response.headers.get('Content-Type') not in PRINTABLE_CONTENT_TYPES:
@@ -197,27 +204,25 @@ def log_before_request(hidden_fields: list[str] | None = None) -> None:
         'headers': LazyHeaderFormatter(request.headers),
     }
 
-    g.request_id = _generate_request_id()
-    g.trace_id = (
-        _parse_traceparent(request.headers.get('traceparent'))
-        or request.headers.get('Wazo-Trace-ID')
-        or _generate_trace_id()
-    )
+    g.span_id = _generate_span_id()
+    trace_context = _parse_traceparent(request.headers.get('traceparent'))
+    if trace_context:
+        g.trace_id = trace_context.trace_id
+        g.parent_id = trace_context.parent_id
+    else:
+        g.trace_id = request.headers.get('Wazo-Trace-ID') or _generate_trace_id()
+        g.parent_id = None
 
-    params['request_id'] = g.request_id
+    params['span_id'] = g.span_id
+    params['parent_id'] = g.parent_id or '-'
     params['trace_id'] = g.trace_id
 
+    ids = '[span_id=%(span_id)s parent_id=%(parent_id)s trace_id=%(trace_id)s]'
     if request.data and request.headers.get('Content-Type') in PRINTABLE_CONTENT_TYPES:
         params['data'] = BodyFormatter(request.data, hidden_fields)
-        fmt = (
-            "request: %(method)s %(url)s %(headers)s with data %(data)s"
-            " [request_id=%(request_id)s] [trace_id=%(trace_id)s]"
-        )
+        fmt = f"request: %(method)s %(url)s %(headers)s with data %(data)s {ids}"
     else:
-        fmt = (
-            "request: %(method)s %(url)s %(headers)s"
-            " [request_id=%(request_id)s] [trace_id=%(trace_id)s]"
-        )
+        fmt = f"request: %(method)s %(url)s %(headers)s {ids}"
 
     current_app.logger.info(fmt, params)
     g.request_time = time.time()

--- a/xivo/tests/test_http_helpers.py
+++ b/xivo/tests/test_http_helpers.py
@@ -45,6 +45,7 @@ class TestLogRequest(unittest.TestCase):
                 200,
                 '-',
                 '-',
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
@@ -68,6 +69,7 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.method,
                 expected_url,
                 200,
+                '-',
                 '-',
                 '-',
             )
@@ -94,6 +96,7 @@ class TestLogRequest(unittest.TestCase):
                 200,
                 '-',
                 '-',
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
@@ -112,11 +115,14 @@ class TestLogRequest(unittest.TestCase):
             log_before_request()
 
             assert_that(g.trace_id, equal_to('4bf92f3577b34da6a3ce929d0e0e4736'))
-            assert_that(g.request_id, matches_regexp(r'^[0-9a-f]{16}$'))
+            assert_that(g.parent_id, equal_to('00f067aa0ba902b7'))
+            assert_that(g.span_id, matches_regexp(r'^[0-9a-f]{16}$'))
             params = mock_current_app.logger.info.call_args[0][-1]
             assert_that(
                 params['trace_id'], equal_to('4bf92f3577b34da6a3ce929d0e0e4736')
             )
+            assert_that(params['parent_id'], equal_to('00f067aa0ba902b7'))
+            assert_that(params['span_id'], equal_to(g.span_id))
 
     @patch('xivo.http_helpers.g', spec={})
     def test_log_before_request_falls_back_to_wazo_trace_id_header(self, g):
@@ -134,9 +140,11 @@ class TestLogRequest(unittest.TestCase):
             log_before_request()
 
             assert_that(g.trace_id, equal_to(wazo_trace_id))
-            assert_that(g.request_id, matches_regexp(r'^[0-9a-f]{16}$'))
+            assert_that(g.parent_id, equal_to(None))
+            assert_that(g.span_id, matches_regexp(r'^[0-9a-f]{16}$'))
             params = mock_current_app.logger.info.call_args[0][-1]
             assert_that(params['trace_id'], equal_to(wazo_trace_id))
+            assert_that(params['parent_id'], equal_to('-'))
 
     @patch('xivo.http_helpers.g', spec={})
     def test_log_before_request_mints_trace_id_when_no_header(self, g):
@@ -150,11 +158,13 @@ class TestLogRequest(unittest.TestCase):
         ):
             log_before_request()
 
-            assert_that(g.request_id, matches_regexp(r'^[0-9a-f]{16}$'))
+            assert_that(g.span_id, matches_regexp(r'^[0-9a-f]{16}$'))
             assert_that(g.trace_id, matches_regexp(r'^[0-9a-f]{32}$'))
+            assert_that(g.parent_id, equal_to(None))
             params = mock_current_app.logger.info.call_args[0][-1]
-            assert_that(params['request_id'], equal_to(g.request_id))
+            assert_that(params['span_id'], equal_to(g.span_id))
             assert_that(params['trace_id'], equal_to(g.trace_id))
+            assert_that(params['parent_id'], equal_to('-'))
 
     @patch('xivo.http_helpers.g', spec={})
     def test_log_before_request_percent_and_brace_in_trace_id_are_safe(self, g):
@@ -176,8 +186,9 @@ class TestLogRequest(unittest.TestCase):
             assert_that(params['trace_id'], equal_to(trace_id))
 
     @patch('xivo.http_helpers.g', spec={})
-    def test_log_request_includes_request_id_and_trace_id(self, g):
-        g.request_id = '0123456789abcdef'
+    def test_log_request_includes_span_parent_and_trace_id(self, g):
+        g.span_id = '0123456789abcdef'
+        g.parent_id = '00f067aa0ba902b7'
         g.trace_id = '4bf92f3577b34da6a3ce929d0e0e4736'
         mock_request = Mock()
         mock_request.url = '/foo/bar'
@@ -197,22 +208,25 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.url,
                 200,
                 '0123456789abcdef',
+                '00f067aa0ba902b7',
                 '4bf92f3577b34da6a3ce929d0e0e4736',
             )
 
 
 class TestParseTraceparent(unittest.TestCase):
-    def test_valid_traceparent_returns_trace_id(self):
+    def test_valid_traceparent_returns_trace_and_parent_id(self):
         value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        assert_that(
-            _parse_traceparent(value), equal_to('4bf92f3577b34da6a3ce929d0e0e4736')
-        )
+        result = _parse_traceparent(value)
+        assert result is not None
+        assert_that(result.trace_id, equal_to('4bf92f3577b34da6a3ce929d0e0e4736'))
+        assert_that(result.parent_id, equal_to('00f067aa0ba902b7'))
 
     def test_mixed_case_traceparent_is_lowercased(self):
         value = '00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01'
-        assert_that(
-            _parse_traceparent(value), equal_to('4bf92f3577b34da6a3ce929d0e0e4736')
-        )
+        result = _parse_traceparent(value)
+        assert result is not None
+        assert_that(result.trace_id, equal_to('4bf92f3577b34da6a3ce929d0e0e4736'))
+        assert_that(result.parent_id, equal_to('00f067aa0ba902b7'))
 
     def test_none_returns_none(self):
         assert_that(_parse_traceparent(None), equal_to(None))

--- a/xivo/tests/test_http_helpers.py
+++ b/xivo/tests/test_http_helpers.py
@@ -10,6 +10,7 @@ from hamcrest import assert_that, equal_to, matches_regexp
 from xivo.http_helpers import (
     BodyFormatter,
     LazyHeaderFormatter,
+    _parse_traceparent,
     log_before_request,
     log_request,
     log_request_hide_token,
@@ -43,7 +44,7 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.url,
                 200,
                 '-',
-                '',
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
@@ -68,7 +69,7 @@ class TestLogRequest(unittest.TestCase):
                 expected_url,
                 200,
                 '-',
-                '',
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
@@ -92,11 +93,33 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.url,
                 200,
                 '-',
-                '',
+                '-',
             )
 
     @patch('xivo.http_helpers.g', spec={})
-    def test_log_before_request_sets_trace_id_from_wazo_trace_id_header(self, g):
+    def test_log_before_request_sets_trace_id_from_traceparent_header(self, g):
+        traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+        mock_request = Mock(data=b'', method='GET')
+        mock_request.headers.get.side_effect = (
+            lambda k, *a: traceparent if k == 'traceparent' else None
+        )
+        mock_request.url = '/foo/bar'
+
+        with (
+            patch('xivo.http_helpers.request', mock_request),
+            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
+        ):
+            log_before_request()
+
+            assert_that(g.trace_id, equal_to('4bf92f3577b34da6a3ce929d0e0e4736'))
+            assert_that(g.request_id, matches_regexp(r'^[0-9a-f]{16}$'))
+            params = mock_current_app.logger.info.call_args[0][-1]
+            assert_that(
+                params['trace_id'], equal_to('4bf92f3577b34da6a3ce929d0e0e4736')
+            )
+
+    @patch('xivo.http_helpers.g', spec={})
+    def test_log_before_request_falls_back_to_wazo_trace_id_header(self, g):
         wazo_trace_id = 'a06f7f341db5b95a-AMS'
         mock_request = Mock(data=b'', method='GET')
         mock_request.headers.get.side_effect = (
@@ -111,19 +134,12 @@ class TestLogRequest(unittest.TestCase):
             log_before_request()
 
             assert_that(g.trace_id, equal_to(wazo_trace_id))
-            assert_that(
-                g.request_id,
-                matches_regexp(
-                    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-                ),
-            )
+            assert_that(g.request_id, matches_regexp(r'^[0-9a-f]{16}$'))
             params = mock_current_app.logger.info.call_args[0][-1]
             assert_that(params['trace_id'], equal_to(wazo_trace_id))
 
     @patch('xivo.http_helpers.g', spec={})
-    def test_log_before_request_generates_uuid_and_omits_trace_id_when_no_header(
-        self, g
-    ):
+    def test_log_before_request_mints_trace_id_when_no_header(self, g):
         mock_request = Mock(data=b'', method='GET')
         mock_request.headers.get = Mock(return_value=None)
         mock_request.url = '/foo/bar'
@@ -134,16 +150,11 @@ class TestLogRequest(unittest.TestCase):
         ):
             log_before_request()
 
-            assert_that(
-                g.request_id,
-                matches_regexp(
-                    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-                ),
-            )
-            assert_that(g.trace_id, equal_to(None))
+            assert_that(g.request_id, matches_regexp(r'^[0-9a-f]{16}$'))
+            assert_that(g.trace_id, matches_regexp(r'^[0-9a-f]{32}$'))
             params = mock_current_app.logger.info.call_args[0][-1]
             assert_that(params['request_id'], equal_to(g.request_id))
-            assert_that('trace_id' in params, equal_to(False))
+            assert_that(params['trace_id'], equal_to(g.trace_id))
 
     @patch('xivo.http_helpers.g', spec={})
     def test_log_before_request_percent_and_brace_in_trace_id_are_safe(self, g):
@@ -165,8 +176,9 @@ class TestLogRequest(unittest.TestCase):
             assert_that(params['trace_id'], equal_to(trace_id))
 
     @patch('xivo.http_helpers.g', spec={})
-    def test_log_request_includes_request_id(self, g):
-        g.request_id = 'test-id-123'
+    def test_log_request_includes_request_id_and_trace_id(self, g):
+        g.request_id = '0123456789abcdef'
+        g.trace_id = '4bf92f3577b34da6a3ce929d0e0e4736'
         mock_request = Mock()
         mock_request.url = '/foo/bar'
         response = Mock(data=None, status_code=200)
@@ -184,34 +196,44 @@ class TestLogRequest(unittest.TestCase):
                 mock_request.method,
                 mock_request.url,
                 200,
-                'test-id-123',
-                '',
+                '0123456789abcdef',
+                '4bf92f3577b34da6a3ce929d0e0e4736',
             )
 
-    @patch('xivo.http_helpers.g', spec={})
-    def test_log_request_includes_trace_id_when_set(self, g):
-        g.request_id = 'some-uuid-1234'
-        g.trace_id = 'a06f7f341db5b95a-AMS'
-        mock_request = Mock()
-        mock_request.url = '/foo/bar'
-        response = Mock(data=None, status_code=200)
 
-        with (
-            patch('xivo.http_helpers.request', mock_request),
-            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
-        ):
-            log_request(response)
+class TestParseTraceparent(unittest.TestCase):
+    def test_valid_traceparent_returns_trace_id(self):
+        value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+        assert_that(
+            _parse_traceparent(value), equal_to('4bf92f3577b34da6a3ce929d0e0e4736')
+        )
 
-            mock_current_app.logger.info.assert_called_once_with(
-                ANY,
-                mock_request.remote_addr,
-                ANY,
-                mock_request.method,
-                mock_request.url,
-                200,
-                'some-uuid-1234',
-                ' [trace_id=a06f7f341db5b95a-AMS]',
-            )
+    def test_mixed_case_traceparent_is_lowercased(self):
+        value = '00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01'
+        assert_that(
+            _parse_traceparent(value), equal_to('4bf92f3577b34da6a3ce929d0e0e4736')
+        )
+
+    def test_none_returns_none(self):
+        assert_that(_parse_traceparent(None), equal_to(None))
+
+    def test_all_zero_trace_id_returns_none(self):
+        value = '00-00000000000000000000000000000000-00f067aa0ba902b7-01'
+        assert_that(_parse_traceparent(value), equal_to(None))
+
+    def test_all_zero_parent_id_returns_none(self):
+        value = '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'
+        assert_that(_parse_traceparent(value), equal_to(None))
+
+    def test_invalid_version_ff_returns_none(self):
+        value = 'ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+        assert_that(_parse_traceparent(value), equal_to(None))
+
+    def test_malformed_returns_none(self):
+        assert_that(_parse_traceparent('not-a-traceparent'), equal_to(None))
+        assert_that(
+            _parse_traceparent('00-tooshort-00f067aa0ba902b7-01'), equal_to(None)
+        )
 
 
 class TestBodyFormatter(unittest.TestCase):

--- a/xivo/tests/test_http_helpers.py
+++ b/xivo/tests/test_http_helpers.py
@@ -125,28 +125,6 @@ class TestLogRequest(unittest.TestCase):
             assert_that(params['span_id'], equal_to(g.span_id))
 
     @patch('xivo.http_helpers.g', spec={})
-    def test_log_before_request_falls_back_to_wazo_trace_id_header(self, g):
-        wazo_trace_id = 'a06f7f341db5b95a-AMS'
-        mock_request = Mock(data=b'', method='GET')
-        mock_request.headers.get.side_effect = (
-            lambda k, *a: wazo_trace_id if k == 'Wazo-Trace-ID' else None
-        )
-        mock_request.url = '/foo/bar'
-
-        with (
-            patch('xivo.http_helpers.request', mock_request),
-            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
-        ):
-            log_before_request()
-
-            assert_that(g.trace_id, equal_to(wazo_trace_id))
-            assert_that(g.parent_id, equal_to(None))
-            assert_that(g.span_id, matches_regexp(r'^[0-9a-f]{16}$'))
-            params = mock_current_app.logger.info.call_args[0][-1]
-            assert_that(params['trace_id'], equal_to(wazo_trace_id))
-            assert_that(params['parent_id'], equal_to('-'))
-
-    @patch('xivo.http_helpers.g', spec={})
     def test_log_before_request_mints_trace_id_when_no_header(self, g):
         mock_request = Mock(data=b'', method='GET')
         mock_request.headers.get = Mock(return_value=None)
@@ -165,25 +143,6 @@ class TestLogRequest(unittest.TestCase):
             assert_that(params['span_id'], equal_to(g.span_id))
             assert_that(params['trace_id'], equal_to(g.trace_id))
             assert_that(params['parent_id'], equal_to('-'))
-
-    @patch('xivo.http_helpers.g', spec={})
-    def test_log_before_request_percent_and_brace_in_trace_id_are_safe(self, g):
-        trace_id = '100%complete{json}'
-        mock_request = Mock(data=b'', method='GET')
-        mock_request.headers.get.side_effect = (
-            lambda k, *a: trace_id if k == 'Wazo-Trace-ID' else None
-        )
-        mock_request.url = '/foo/bar'
-
-        with (
-            patch('xivo.http_helpers.request', mock_request),
-            patch('xivo.http_helpers.current_app', Mock()) as mock_current_app,
-        ):
-            log_before_request()
-
-            assert_that(g.trace_id, equal_to(trace_id))
-            params = mock_current_app.logger.info.call_args[0][-1]
-            assert_that(params['trace_id'], equal_to(trace_id))
 
     @patch('xivo.http_helpers.g', spec={})
     def test_log_request_includes_span_parent_and_trace_id(self, g):


### PR DESCRIPTION
through traceparent header

why: opentelemetry standard compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Observability contract changes: log field names and correlation IDs differ, and upstreams must send `traceparent` instead of `Wazo-Trace-ID` for distributed tracing.
> 
> **Overview**
> Replaces per-request UUID **`request_id`** and the custom **`Wazo-Trace-ID`** header with **W3C Trace Context** fields on Flask **`g`** and in request/response log lines.
> 
> **`log_before_request`** now always mints a **`span_id`**, parses **`traceparent`** when present (otherwise generates a **`trace_id`** and leaves **`parent_id`** unset), and logs **`[span_id=… parent_id=… trace_id=…]`** on every request. **`_parse_traceparent`** validates the header (version, all-zero IDs, malformed values) and returns lowercased trace/parent IDs. IDs are generated with **`secrets.token_hex`** instead of **`uuid`**.
> 
> Tests were updated for the new log format and **`TestParseTraceparent`** was added for the parser edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ce750ac0e53fd35b874a17d3b65baa751239e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->