### PR TITLE
ITEM-391-typing

### DIFF
--- a/xivo/consul_helpers.py
+++ b/xivo/consul_helpers.py
@@ -95,8 +95,8 @@ class ServiceCatalogRegistration:
 
     def __exit__(
         self,
-        type: type[BaseException],
-        value: BaseException,
+        type: type[BaseException] | None,
+        value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
         if type:

--- a/xivo/token_renewer.py
+++ b/xivo/token_renewer.py
@@ -136,8 +136,8 @@ class TokenRenewer:
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_value: BaseException,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
         traceback: types.TracebackType | None,
     ) -> None:
         self.stop()


### PR DESCRIPTION
Why: TokenRenewer and ServiceCatalogRegistration declared __exit__ with
exc_type/exc_value as non-optional, so they failed the AbstractContextManager
protocol and mypy rejected them in ExitStack.enter_context() callers.
The runtime always allows None on a clean exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes to context manager `__exit__` signatures; no logic or runtime behavior changes.
> 
> **Overview**
> Updates **`__exit__`** signatures on **`ServiceCatalogRegistration`** and **`TokenRenewer`** so exception type and value parameters are typed as optional (`| None`), matching normal context-manager behavior on a clean exit.
> 
> This aligns both classes with the **`AbstractContextManager`** protocol so mypy accepts them when used with **`ExitStack.enter_context()`** and similar callers. Runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ffc9bbb0300dcc60cbd28f884738c5fd2dec9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->