### PR TITLE
ITEM-391-typing-xivo-lib

### DIFF
--- a/xivo/consul_helpers.py
+++ b/xivo/consul_helpers.py
@@ -62,9 +62,9 @@ class ServiceCatalogRegistration:
         self,
         service_name: str,
         uuid: str,
-        consul_config: dict[str, Any],
-        service_discovery_config: dict[str, Any],
-        bus_config: dict[str, Any],
+        consul_config: Mapping[str, Any],
+        service_discovery_config: Mapping[str, Any],
+        bus_config: Mapping[str, Any],
         check: Callable[[], bool] | None = None,
     ) -> None:
         self._enabled = service_discovery_config.get('enabled', True)
@@ -156,8 +156,8 @@ class Registerer:
         self,
         name: str,
         uuid: str,
-        consul_config: dict[str, Any],
-        service_discovery_config: dict[str, Any],
+        consul_config: Mapping[str, Any],
+        service_discovery_config: Mapping[str, Any],
     ) -> None:
         self._service_id = str(uuid4())
         self._service_name = name
@@ -230,11 +230,11 @@ class Registerer:
         except (ConnectionError, ConsulException) as e:
             raise RegistererError(str(e))
 
-    def _find_address(self, service_discovery_config: dict[str, Any]) -> str:
+    def _find_address(self, service_discovery_config: Mapping[str, Any]) -> str:
         return address_from_config(service_discovery_config)
 
 
-def address_from_config(service_discovery_config: dict[str, Any]) -> str:
+def address_from_config(service_discovery_config: Mapping[str, Any]) -> str:
     advertise_address = service_discovery_config['advertise_address']
     if advertise_address != 'auto':
         return advertise_address
@@ -269,9 +269,9 @@ class NotifyingRegisterer(Registerer):
         self,
         name: str,
         uuid: str,
-        consul_config: dict[str, Any],
-        service_discovery_config: dict[str, Any],
-        bus_config: dict[str, Any],
+        consul_config: Mapping[str, Any],
+        service_discovery_config: Mapping[str, Any],
+        bus_config: Mapping[str, Any],
     ) -> None:
         super().__init__(name, uuid, consul_config, service_discovery_config)
         self._publisher = BusPublisher(


### PR DESCRIPTION
Why: these config sections are only read, never mutated; Mapping lets
callers pass TypedDict config sections without casts. Matches
ServiceFinder, which already takes Mapping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change with no runtime behavior; lowest risk unless downstream code relied on mutating those dicts through the old types (unlikely).
> 
> **Overview**
> Updates type annotations in `xivo/consul_helpers.py` so Consul-related config arguments use **`Mapping[str, Any]`** instead of **`dict[str, Any]`** on `ServiceCatalogRegistration`, `Registerer`, `NotifyingRegisterer`, and helpers like `address_from_config` / `_find_address`.
> 
> This reflects that those configs are only read (`.get`, key lookups, unpacking), so callers can pass **`TypedDict`** sections without casts. **`ServiceFinder`** already accepted `Mapping`; this aligns the registration path with that pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f56e9cf8350adff6edfb534b6107311ac1d282e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->