### PR TITLE
ITEM-391-typing-xivo-lib

### DIFF
--- a/xivo/consul_helpers.py
+++ b/xivo/consul_helpers.py
@@ -61,7 +61,7 @@ class ServiceCatalogRegistration:
     def __init__(
         self,
         service_name: str,
-        uuid: str,
+        uuid: str | None,
         consul_config: Mapping[str, Any],
         service_discovery_config: Mapping[str, Any],
         bus_config: Mapping[str, Any],
@@ -72,6 +72,7 @@ class ServiceCatalogRegistration:
             logger.debug('service discovery has been disabled')
             return
 
+        assert uuid is not None
         self._check = check or self._default_check
         self._registerer = NotifyingRegisterer(
             service_name, uuid, consul_config, service_discovery_config, bus_config


### PR DESCRIPTION
Why: callers may construct it with no uuid when service discovery is
disabled (the uuid is only needed to register). Widen the param and
narrow with an assert before building the registerer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-signature and runtime assert only; behavior unchanged when discovery is enabled and uuid is provided.
> 
> **Overview**
> **Typing fix** for `ServiceCatalogRegistration`: the `uuid` constructor parameter is now `str | None` instead of `str`, matching callers that pass no uuid when service discovery is disabled.
> 
> When discovery stays enabled, an **`assert uuid is not None`** runs before `NotifyingRegisterer` is created, so registration still requires a real uuid at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1868dbf221dad4afa594075ed13598cc923e215d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->