### PR TITLE
ITEM-391-typing-xivo-lib

### DIFF
--- a/xivo/status.py
+++ b/xivo/status.py
@@ -1,13 +1,13 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, Collection
-from typing import DefaultDict
+from typing import Any, DefaultDict
 
-StatusDict = DefaultDict[str, DefaultDict[str, str]]
+StatusDict = DefaultDict[str, Any]
 StatusProvider = Callable[[StatusDict], None]
 
 


### PR DESCRIPTION
Why: the status structure is a recursive defaultdict whose leaves are
arbitrary scalars (str status flags, int counters), so the previous
DefaultDict[str, DefaultDict[str, str]] forced callers reporting numeric
counters to use type: ignore. Any reflects the actual contents and lets
providers assign plain dicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static typing-only change to a shared status alias; no runtime behavior change.
> 
> **Overview**
> **`StatusDict`** is now typed as `DefaultDict[str, Any]` instead of a two-level `DefaultDict[str, DefaultDict[str, str]]`, matching how status providers actually fill the tree (nested groups plus mixed leaf values like status strings and numeric counters).
> 
> Callers that report non-string leaves no longer need `# type: ignore` on those assignments. Copyright year in `xivo/status.py` is updated to 2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f35ad6647e14d397c8616bcdfd106cb217a2df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->