### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/integration_tests/Dockerfile-dynamic-wsgi
+++ b/integration_tests/Dockerfile-dynamic-wsgi
@@ -1,0 +1,15 @@
+FROM python:3.11-slim-bookworm
+
+# gcc is needed for 'netifaces'
+RUN apt update && apt install --assume-yes gcc
+
+COPY integration_tests/assets/bin/dynamic-wsgi-server.py /usr/local/bin
+COPY . /usr/local/src/xivo-lib-python
+
+RUN cd /usr/local/src/xivo-lib-python && \
+    python3 -m pip install -r requirements.txt && \
+    python3 -m pip install 'flask-restful==0.3.9' && \
+    python setup.py install
+
+EXPOSE 8080
+CMD ["python3", "/usr/local/bin/dynamic-wsgi-server.py"]

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -4,7 +4,7 @@ egg-info:
 myservice:
 	docker build -t myservice -f Dockerfile-myservice ..
 
-test-setup: myservice thread-exception wsgi-patch egg-info
+test-setup: myservice thread-exception wsgi-patch dynamic-wsgi egg-info
 
 test:
 	pytest suite
@@ -15,4 +15,7 @@ thread-exception:
 wsgi-patch:
 	docker build -t wsgi-patch -f Dockerfile-wsgi-patch ..
 
-.PHONY: egg-info test-setup test myservice thread-exception
+dynamic-wsgi:
+	docker build -t dynamic-wsgi -f Dockerfile-dynamic-wsgi ..
+
+.PHONY: egg-info test-setup test myservice thread-exception dynamic-wsgi

--- a/integration_tests/assets/bin/dynamic-wsgi-server.py
+++ b/integration_tests/assets/bin/dynamic-wsgi-server.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+from time import sleep
+
+from flask import Flask
+from flask_restful import Api, Resource
+
+from xivo import wsgi
+
+logging.basicConfig(level=logging.INFO)
+
+app = Flask('dynamic-wsgi-server')
+api = Api(app)
+
+
+class SlowResource(Resource):
+    def get(self) -> str:
+        sleep(3)
+        return 'done'
+
+
+def main() -> None:
+    api.add_resource(SlowResource, '/slow')
+    bind_addr = ('0.0.0.0', 8080)
+    wsgi_app = wsgi.WSGIPathInfoDispatcher({'/': app})
+    server = wsgi.DynamicWSGIServer(
+        bind_addr,
+        wsgi_app,
+        server_name='dynamic-wsgi-server',
+        numthreads=2,
+        max=6,
+        minspare=1,
+        maxspare=2,
+        resize_interval=1.0,
+    )
+    server.start()
+
+
+if __name__ == '__main__':
+    main()

--- a/integration_tests/assets/docker-compose.dynamic-wsgi.override.yml
+++ b/integration_tests/assets/docker-compose.dynamic-wsgi.override.yml
@@ -1,0 +1,6 @@
+services:
+  sync:
+    depends_on:
+      - dynamic-wsgi
+    environment:
+      TARGETS: ''

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -34,3 +34,11 @@ services:
       nofile:
         soft: 50
         hard: 55
+
+  dynamic-wsgi:
+    image: dynamic-wsgi
+    volumes:
+      - ../..:/usr/local/src/xivo-lib-python:ro
+    ports:
+      - "8080"
+    restart: "no"

--- a/integration_tests/suite/test_dynamic_wsgi.py
+++ b/integration_tests/suite/test_dynamic_wsgi.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+from hamcrest import assert_that, contains_string, equal_to
+from wazo_test_helpers import until
+from wazo_test_helpers.asset_launching_test_case import AssetLaunchingTestCase
+
+ASSET_ROOT = os.path.join(os.path.dirname(__file__), '..', 'assets')
+
+
+class TestDynamicWSGIServer(AssetLaunchingTestCase):
+    assets_root = ASSET_ROOT
+    service = 'dynamic-wsgi'
+    asset = 'dynamic-wsgi'
+
+    def test_pool_grows_under_load_and_shrinks_after(self) -> None:
+        server_ip = '127.0.0.1'
+        service_port = self.service_port(8080, 'dynamic-wsgi')
+        url = f'http://{server_ip}:{service_port}/slow'
+
+        # numthreads=2: 5 concurrent slow requests force the pool to grow.
+        with self.capture_logs('dynamic-wsgi') as logs:
+            with ThreadPoolExecutor(max_workers=5) as pool:
+                futures = [pool.submit(requests.get, url, timeout=10) for _ in range(5)]
+                for future in futures:
+                    response = future.result()
+                    assert_that(response.status_code, equal_to(200))
+
+        assert_that(logs.result(), contains_string('WSGI thread pool grown'))
+
+        def shrunk() -> None:
+            assert_that(
+                self.service_logs('dynamic-wsgi'),
+                contains_string('WSGI thread pool shrink requested'),
+            )
+
+        until.assert_(shrunk, tries=10, interval=1)

--- a/xivo/tests/test_wsgi.py
+++ b/xivo/tests/test_wsgi.py
@@ -1,0 +1,166 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+
+from cheroot.workers.threadpool import ThreadPool
+from hamcrest import assert_that, equal_to
+
+from ..wsgi import _REQUIRED_POOL_INTERNALS, DynamicWSGIServer, _compute_adjustment
+
+
+class TestCherootPoolInternals(unittest.TestCase):
+    def test_required_private_attributes_exist(self):
+        # DynamicWSGIServer relies on these private cheroot attributes; fail
+        # loudly here when a cheroot upgrade renames one.
+        pool = ThreadPool(server=None)
+
+        for name in _REQUIRED_POOL_INTERNALS:
+            assert_that(hasattr(pool, name), equal_to(True), name)
+
+
+class TestComputeAdjustment(unittest.TestCase):
+    def _compute(self, **kwargs):
+        defaults = {
+            'threads': 10,
+            'idle': 5,
+            'qsize': 0,
+            'min_threads': 2,
+            'max_threads': 50,
+            'minspare': 2,
+            'maxspare': 8,
+        }
+        defaults.update(kwargs)
+        return _compute_adjustment(**defaults)
+
+    def test_steady_state_does_nothing(self):
+        assert_that(self._compute(idle=5, qsize=0), equal_to(0))
+
+    def test_grows_to_maintain_minspare(self):
+        assert_that(self._compute(idle=0, qsize=0, minspare=2), equal_to(2))
+        assert_that(self._compute(idle=1, qsize=0, minspare=2), equal_to(1))
+
+    def test_grows_by_backlog_on_top_of_minspare(self):
+        assert_that(self._compute(idle=0, qsize=5, minspare=2), equal_to(7))
+
+    def test_grows_only_for_backlog_beyond_idle_workers(self):
+        assert_that(self._compute(idle=3, qsize=4, minspare=2), equal_to(1))
+
+    def test_backlog_covered_by_idle_workers_does_nothing(self):
+        assert_that(self._compute(idle=5, qsize=3, minspare=2), equal_to(0))
+
+    def test_growth_is_capped_by_max_threads(self):
+        assert_that(
+            self._compute(threads=48, idle=0, qsize=10, max_threads=50),
+            equal_to(2),
+        )
+
+    def test_growth_at_max_threads_does_nothing(self):
+        assert_that(
+            self._compute(threads=50, idle=0, qsize=10, max_threads=50),
+            equal_to(0),
+        )
+
+    def test_negative_max_threads_means_unbounded_growth(self):
+        assert_that(
+            self._compute(threads=100, idle=0, qsize=10, max_threads=-1),
+            equal_to(12),
+        )
+
+    def test_growth_is_capped_at_doubling_per_tick(self):
+        assert_that(
+            self._compute(threads=10, idle=0, qsize=100, max_threads=-1),
+            equal_to(10),
+        )
+
+    def test_shrinks_one_thread_per_tick_above_maxspare(self):
+        assert_that(self._compute(threads=20, idle=12, maxspare=8), equal_to(-1))
+
+    def test_shrink_at_min_threads_does_nothing(self):
+        assert_that(
+            self._compute(threads=2, idle=2, min_threads=2, maxspare=1),
+            equal_to(0),
+        )
+
+
+class TestDynamicWSGIServerEnablement(unittest.TestCase):
+    # Instantiating the server does not bind any socket (that happens in
+    # prepare()), so building instances in unit tests is safe.
+
+    def _new_server(self, **kwargs):
+        def app(environ, start_response):
+            return []
+
+        return DynamicWSGIServer(('127.0.0.1', 0), app, **kwargs)
+
+    def test_enabled_when_min_below_max(self):
+        server = self._new_server(numthreads=2, max=10)
+
+        assert_that(server._dynamic_enabled, equal_to(True))
+
+    def test_enabled_when_unbounded(self):
+        server = self._new_server(numthreads=2, max=-1)
+
+        assert_that(server._dynamic_enabled, equal_to(True))
+
+    def test_disabled_with_info_when_min_equals_max(self):
+        with self.assertLogs('xivo.wsgi', level='INFO') as logs:
+            server = self._new_server(numthreads=10, max=10)
+
+        assert_that(server._dynamic_enabled, equal_to(False))
+        assert_that(logs.records[0].levelname, equal_to('INFO'))
+
+    def test_disabled_with_warning_when_min_above_max(self):
+        with self.assertLogs('xivo.wsgi', level='WARNING') as logs:
+            server = self._new_server(numthreads=20, max=10)
+
+        assert_that(server._dynamic_enabled, equal_to(False))
+        assert_that(logs.records[0].levelname, equal_to('WARNING'))
+
+    def test_minspare_above_maxspare_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self._new_server(minspare=10, maxspare=8)
+
+    def test_negative_minspare_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self._new_server(minspare=-1, maxspare=8)
+
+    def test_non_positive_resize_interval_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self._new_server(resize_interval=0)
+        with self.assertRaises(ValueError):
+            self._new_server(resize_interval=-5.0)
+
+
+class FakePool:
+    def __init__(self, fail_at=None):
+        self._threads = []
+        self._fail_at = fail_at
+
+    def _spawn_worker(self):
+        if self._fail_at is not None and len(self._threads) >= self._fail_at:
+            raise RuntimeError("can't start new thread")
+        return object()
+
+
+class TestGrowPool(unittest.TestCase):
+    def _new_server(self):
+        def app(environ, start_response):
+            return []
+
+        return DynamicWSGIServer(('127.0.0.1', 0), app)
+
+    def test_spawns_the_requested_amount(self):
+        pool = FakePool()
+
+        self._new_server()._grow_pool(pool, 3)
+
+        assert_that(len(pool._threads), equal_to(3))
+
+    def test_partial_spawn_failure_keeps_started_workers_registered(self):
+        pool = FakePool(fail_at=2)
+
+        with self.assertRaises(RuntimeError):
+            self._new_server()._grow_pool(pool, 5)
+
+        assert_that(len(pool._threads), equal_to(2))

--- a/xivo/tests/test_wsgi.py
+++ b/xivo/tests/test_wsgi.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
+from unittest.mock import patch
 
 from cheroot.workers.threadpool import ThreadPool
-from hamcrest import assert_that, equal_to
+from cheroot.wsgi import Server
+from hamcrest import assert_that, equal_to, none, not_none
 
 from ..wsgi import _REQUIRED_POOL_INTERNALS, DynamicWSGIServer, _compute_adjustment
 
@@ -130,6 +132,52 @@ class TestDynamicWSGIServerEnablement(unittest.TestCase):
             self._new_server(resize_interval=0)
         with self.assertRaises(ValueError):
             self._new_server(resize_interval=-5.0)
+
+
+class TestPrepareStartsMonitor(unittest.TestCase):
+    # cheroot's Server.prepare() binds a socket; it is mocked out so these
+    # tests only exercise the monitor thread startup logic layered on top.
+
+    def _new_server(self, **kwargs):
+        def app(environ, start_response):
+            return []
+
+        return DynamicWSGIServer(('127.0.0.1', 0), app, **kwargs)
+
+    def _stop_monitor(self, server):
+        server._monitor_stopped.set()
+        if server._monitor_thread is not None:
+            server._monitor_thread.join()
+
+    def test_prepare_does_not_start_monitor_when_scaling_disabled(self):
+        with self.assertLogs('xivo.wsgi', level='INFO'):
+            server = self._new_server(numthreads=10, max=10)
+
+        with patch.object(Server, 'prepare'):
+            server.prepare()
+
+        assert_that(server._monitor_thread, none())
+
+    def test_prepare_starts_monitor_when_scaling_enabled(self):
+        server = self._new_server(numthreads=2, max=10)
+
+        with patch.object(Server, 'prepare'):
+            server.prepare()
+        self.addCleanup(self._stop_monitor, server)
+
+        assert_that(server._monitor_thread, not_none())
+        assert_that(server._monitor_thread.is_alive(), equal_to(True))
+
+    def test_prepare_restarts_monitor_after_a_previous_stop(self):
+        server = self._new_server(numthreads=2, max=10)
+        server._monitor_stopped.set()
+
+        with patch.object(Server, 'prepare'):
+            server.prepare()
+        self.addCleanup(self._stop_monitor, server)
+
+        assert_that(server._monitor_stopped.is_set(), equal_to(False))
+        assert_that(server._monitor_thread.is_alive(), equal_to(True))
 
 
 class FakePool:

--- a/xivo/wsgi.py
+++ b/xivo/wsgi.py
@@ -90,6 +90,11 @@ def _compute_adjustment(
         # queue shutdown requests ahead of incoming connections.
         return -1
 
+    # Unlike dynpool's reference algorithm, there is no explicit
+    # ``min_threads - threads`` regrow term: cheroot workers only die outside
+    # shrink() in exceptional cases, and a depleted pool regrows on demand
+    # through the minspare branch above.
+
     return 0
 
 
@@ -154,6 +159,9 @@ class DynamicWSGIServer(PatchedWSGIServer):
         super().prepare()
         if not self._dynamic_enabled:
             return
+        # cheroot servers may be restarted after stop(); reset the flag so
+        # the new monitor does not exit on its first tick.
+        self._monitor_stopped.clear()
         # Non-daemon: grown workers inherit this thread's daemon flag, and
         # daemon workers would be killed mid-request at interpreter exit.
         self._monitor_thread = threading.Thread(
@@ -176,7 +184,10 @@ class DynamicWSGIServer(PatchedWSGIServer):
             try:
                 self._resize_pool()
             except Exception:
-                # Best-effort: a stale pool size beats a dead monitor.
+                # Best-effort: a stale pool size beats a dead monitor. A
+                # persistent failure (e.g. thread limit reached) retries and
+                # logs one traceback per tick — bounded by resize_interval,
+                # unlike the fd flood PatchedWSGIServer guards against.
                 logger.exception('Error while resizing the WSGI thread pool')
 
     def _resize_pool(self) -> None:

--- a/xivo/wsgi.py
+++ b/xivo/wsgi.py
@@ -154,6 +154,12 @@ class DynamicWSGIServer(PatchedWSGIServer):
                 pool.min,
                 pool.max,
             )
+        else:
+            logger.info(
+                'Dynamic thread pool scaling enabled (min %d -> max %d)',
+                pool.min,
+                pool.max,
+            )
 
     def prepare(self) -> None:
         super().prepare()

--- a/xivo/wsgi.py
+++ b/xivo/wsgi.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import threading
 import time
 from collections.abc import Callable
 from typing import Any
@@ -52,6 +53,164 @@ class PatchedWSGIServer(Server):  # noqa
                 time.sleep(0.1)
             if self.interrupt:
                 raise self.interrupt
+
+
+# Private cheroot attributes the resize path needs; probed at startup since
+# the production cheroot version is not constrained.
+_REQUIRED_POOL_INTERNALS = ('_clear_dead_threads', '_spawn_worker', '_threads')
+
+
+def _compute_adjustment(
+    threads: int,
+    idle: int,
+    qsize: int,
+    min_threads: int,
+    max_threads: int,
+    minspare: int,
+    maxspare: int,
+) -> int:
+    """Decide how to resize a cheroot thread pool.
+
+    Returns the number of threads to add (positive), remove (negative)
+    or 0 to leave the pool as is. ``max_threads <= 0`` means unbounded,
+    matching cheroot's ``ThreadPool.max`` semantics.
+    """
+    # Grow for the spare buffer plus the backlog idle workers cannot absorb
+    # (qsize is an instantaneous snapshot; the full backlog would overreact).
+    wanted = max(minspare - idle, 0) + max(qsize - idle, 0)
+    if wanted > 0:
+        # At most double per tick: bounds reconnect storms on unbounded pools.
+        wanted = min(wanted, max(threads, 1))
+        if max_threads > 0:
+            wanted = min(wanted, max(max_threads - threads, 0))
+        return wanted
+
+    if idle > maxspare and threads > min_threads:
+        # One thread per tick: mass shrinks oscillate on bursty load and
+        # queue shutdown requests ahead of incoming connections.
+        return -1
+
+    return 0
+
+
+class DynamicWSGIServer(PatchedWSGIServer):
+    """A WSGI server whose thread pool grows and shrinks with demand.
+
+    cheroot's ThreadPool exposes grow()/shrink() but never calls them:
+    ``numthreads`` workers are spawned at startup and live forever. This
+    server keeps ``numthreads`` as the pool minimum, ``max`` as the pool
+    maximum, and runs a monitor thread that resizes the pool every
+    ``resize_interval`` seconds to keep between ``minspare`` and
+    ``maxspare`` idle workers.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        minspare: int = 2,
+        maxspare: int = 8,
+        resize_interval: float = 5.0,
+        **kwargs: Any,
+    ) -> None:
+        if minspare < 0 or maxspare < minspare:
+            raise ValueError(
+                f'expected 0 <= minspare <= maxspare, got {minspare=} {maxspare=}'
+            )
+        if resize_interval <= 0:
+            raise ValueError(f'expected resize_interval > 0, got {resize_interval}')
+        super().__init__(*args, **kwargs)
+        self._minspare = minspare
+        self._maxspare = maxspare
+        self._resize_interval = resize_interval
+        self._monitor_stopped = threading.Event()
+        self._monitor_thread: threading.Thread | None = None
+        pool = self.requests
+        self._dynamic_enabled = True
+        missing_internals = [
+            name for name in _REQUIRED_POOL_INTERNALS if not hasattr(pool, name)
+        ]
+        if missing_internals:
+            self._dynamic_enabled = False
+            logger.warning(
+                'cheroot ThreadPool internals %s are missing: '
+                'thread pool scaling disabled',
+                missing_internals,
+            )
+        elif pool.min == pool.max:
+            self._dynamic_enabled = False
+            logger.info(
+                'min_threads == max_threads (%s): thread pool scaling disabled',
+                pool.min,
+            )
+        elif 0 < pool.max < pool.min:
+            self._dynamic_enabled = False
+            logger.warning(
+                'min_threads (%s) > max_threads (%s): thread pool scaling disabled',
+                pool.min,
+                pool.max,
+            )
+
+    def prepare(self) -> None:
+        super().prepare()
+        if not self._dynamic_enabled:
+            return
+        # Non-daemon: grown workers inherit this thread's daemon flag, and
+        # daemon workers would be killed mid-request at interpreter exit.
+        self._monitor_thread = threading.Thread(
+            target=self._monitor_pool,
+            name='WSGIThreadPoolMonitor',
+            daemon=False,
+        )
+        self._monitor_thread.start()
+
+    def stop(self) -> None:
+        self._monitor_stopped.set()
+        if self._monitor_thread is not None:
+            # No timeout: giving up mid-resize lets pool.stop() race an
+            # in-flight grow, hanging shutdown; the monitor exits quickly.
+            self._monitor_thread.join()
+        super().stop()
+
+    def _monitor_pool(self) -> None:
+        while not self._monitor_stopped.wait(self._resize_interval):
+            try:
+                self._resize_pool()
+            except Exception:
+                # Best-effort: a stale pool size beats a dead monitor.
+                logger.exception('Error while resizing the WSGI thread pool')
+
+    def _resize_pool(self) -> None:
+        pool = self.requests
+        # cheroot culls dead workers only inside shrink(); cull before
+        # measuring so the stats do not freeze on dead threads.
+        pool._clear_dead_threads()
+        threads = len(pool._threads)
+        adjustment = _compute_adjustment(
+            threads=threads,
+            idle=pool.idle,
+            qsize=pool.qsize,
+            min_threads=pool.min,
+            max_threads=pool.max,
+            minspare=self._minspare,
+            maxspare=self._maxspare,
+        )
+        if adjustment > 0:
+            self._grow_pool(pool, adjustment)
+            logger.info('WSGI thread pool grown: %s -> %s', threads, len(pool._threads))
+        elif adjustment < 0:
+            pool.shrink(-adjustment)
+            logger.info(
+                'WSGI thread pool shrink requested: %s -> %s',
+                threads,
+                threads + adjustment,
+            )
+
+    def _grow_pool(self, pool: Any, amount: int) -> None:
+        # Not pool.grow(): its wait-until-ready spin wedges forever if a
+        # worker dies before becoming ready, and its bulk spawn leaks
+        # workers when creation fails partway.
+        for _ in range(amount):
+            pool._threads.append(pool._spawn_worker())
 
 
 WSGIServer = PatchedWSGIServer


### PR DESCRIPTION
Why: cheroot spawns numthreads workers at startup and never resizes
the pool, so services permanently hold their peak thread count and
cannot absorb bursts. A monitor thread keeps a small buffer of idle
workers, growing and shrinking the pool between numthreads and max.

Design notes:
- Growth covers the spare buffer plus the backlog idle workers cannot
  absorb, capped at doubling per tick; shrink is one thread per tick.
  Both bounds avoid grow/shrink oscillation on bursty load and thread
  storms on unbounded pools (max_threads <= 0).
- Workers are spawned directly instead of via pool.grow(): its
  wait-until-ready spin can wedge the monitor forever, and its bulk
  spawn leaks running workers when thread creation fails partway.
- The monitor is non-daemon so grown workers match the initial ones
  (the daemon flag is inherited); stop() joins it before stopping the
  pool so an in-flight grow cannot race ThreadPool.stop().
- Dead threads are culled before each measurement: cheroot culls only
  inside shrink(), so pool stats would freeze after a shrink.
- The private cheroot attributes used are probed once at startup and
  scaling is disabled with a warning when one is missing, since the
  cheroot version is not constrained in production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HTTP serving and cheroot private APIs; mis-sizing or monitor races could affect concurrency and shutdown, though scaling is opt-in and guarded with fallbacks.
> 
> **Overview**
> Adds **`DynamicWSGIServer`** on top of **`PatchedWSGIServer`**: a background monitor periodically resizes cheroot’s thread pool between **`numthreads`** and **`max`**, using **`minspare`/`maxspare`** and **`resize_interval`**. Sizing is driven by **`_compute_adjustment`** (grow for spare + backlog, capped per tick; shrink one thread at a time). Workers are added via **`_spawn_worker`** instead of **`pool.grow()`**; scaling turns off when cheroot internals are missing or min/max are invalid.
> 
> **`WSGIServer`** stays **`PatchedWSGIServer`**—callers opt into dynamic scaling explicitly. Coverage includes **`xivo/tests/test_wsgi.py`** and a **`dynamic-wsgi`** Docker integration test that asserts grow/shrink log lines under concurrent slow requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0fb6323da875ea9bf34c901711bd4ffbb82f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->