### PR TITLE
ITEM-539 xivo/xivo_logging: fix timestamp format

### DIFF
--- a/xivo/tests/test_xivo_logging.py
+++ b/xivo/tests/test_xivo_logging.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import os
 import sys
 import tempfile
+import time
 from io import StringIO
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -16,10 +18,10 @@ from hamcrest import (
     has_length,
     is_,
     is_not,
+    matches_regexp,
 )
 
 from xivo.xivo_logging import (
-    DEFAULT_LOG_DATEFMT,
     DEFAULT_LOG_FORMAT,
     DEFAULT_LOG_LEVEL,
     excepthook,
@@ -35,23 +37,21 @@ class TestLogging(TestCase):
         log_file = 'my_log_file.log'
         root_logger = logging.getLogger.return_value
         file_handler = logging.FileHandler.return_value
-        formatter = logging.Formatter.return_value
 
         setup_logging(log_file)
 
         logging.FileHandler.assert_called_once_with(log_file)
-        file_handler.setFormatter.assert_called_once_with(formatter)
+        file_handler.setFormatter.assert_called_once()
         root_logger.addHandler.assert_any_call(file_handler)
 
     def test_setup_logging_then_stream_logging(self, logging):
         log_file = Mock()
         root_logger = logging.getLogger.return_value
         stream_handler = logging.StreamHandler.return_value
-        formatter = logging.Formatter.return_value
 
         setup_logging(log_file)
 
-        stream_handler.setFormatter.assert_any_call(formatter)
+        stream_handler.setFormatter.assert_called()
         root_logger.addHandler.assert_any_call(stream_handler)
 
     def test_setup_logging_with_no_flags_then_log_level_is_default(self, logging):
@@ -90,22 +90,22 @@ class TestLogging(TestCase):
 
     def test_setup_logging_with_no_format_then_log_format_is_default(self, logging):
         log_file = Mock()
+        file_handler = logging.FileHandler.return_value
 
         setup_logging(log_file)
 
-        logging.Formatter.assert_called_once_with(
-            DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATEFMT
-        )
+        formatter = file_handler.setFormatter.call_args.args[0]
+        assert_that(formatter._fmt, equal_to(DEFAULT_LOG_FORMAT))
 
     def test_setup_logging_with_format_then_log_format_is_not_default(self, logging):
         log_file = Mock()
         log_format = '%(message)s'
+        file_handler = logging.FileHandler.return_value
 
         setup_logging(log_file, log_format=log_format)
 
-        logging.Formatter.assert_called_once_with(
-            log_format, datefmt=DEFAULT_LOG_DATEFMT
-        )
+        formatter = file_handler.setFormatter.call_args.args[0]
+        assert_that(formatter._fmt, equal_to(log_format))
 
     def test_that_setup_logging_adds_excepthook(self, logging):
         log_file = Mock()
@@ -115,6 +115,40 @@ class TestLogging(TestCase):
 
             assert_that(sys.excepthook, is_not(new_hook))
             assert_that(sys.excepthook, is_(excepthook))
+
+
+class TestLoggingFormat(TestCase):
+    def setUp(self):
+        _, self.file_name = tempfile.mkstemp()
+        self._previous_tz = os.environ.get('TZ')
+        os.environ['TZ'] = 'UTC'
+        time.tzset()
+
+    def tearDown(self):
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+
+        if self._previous_tz is None:
+            os.environ.pop('TZ', None)
+        else:
+            os.environ['TZ'] = self._previous_tz
+        time.tzset()
+
+    def test_setup_logging_default_format_has_timezone_and_microsecond_timestamp(self):
+        setup_logging(self.file_name)
+        logging.getLogger('test').info('message')
+
+        with open(self.file_name) as log_file:
+            log_line = log_file.readline()
+
+        assert_that(
+            log_line,
+            matches_regexp(
+                r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} UTC'
+                r' \[pid \d+\] \[tid \d+\] \(INFO\) \(test\): message\n$'
+            ),
+        )
 
 
 @patch('sys.stderr', new_callable=StringIO)

--- a/xivo/xivo_logging.py
+++ b/xivo/xivo_logging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
 import types
 from collections.abc import Callable, Sequence
 
@@ -12,8 +13,20 @@ DEFAULT_LOG_FORMAT = (
     '%(asctime)s [pid %(process)d] [tid %(thread)d] (%(levelname)s)'
     ' (%(name)s): %(message)s'
 )
-DEFAULT_LOG_DATEFMT = '%Y-%m-%d %H:%M:%S %Z'
+DEFAULT_LOG_DATEFMT = '%Y-%m-%d %H:%M:%S'
 DEFAULT_LOG_LEVEL = logging.INFO
+
+
+# need a custom Formatter to get around default formatter quirks w.r.t. timestamp format
+class _Formatter(logging.Formatter):
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        ct = self.converter(record.created)
+        assert datefmt is None
+        date = time.strftime(DEFAULT_LOG_DATEFMT, ct)
+        tz = time.strftime('%Z', ct)
+        # need to replicate stdlib default logic to get milisecond precision
+        # and still include timezone info
+        return f'{date},{int(record.msecs):03d} {tz}'
 
 
 class _StreamToLogger:
@@ -56,7 +69,6 @@ def setup_logging(
     debug: bool = False,
     log_level: int = DEFAULT_LOG_LEVEL,
     log_format: str = DEFAULT_LOG_FORMAT,
-    log_datefmt: str = DEFAULT_LOG_DATEFMT,
 ) -> None:
     """
     logger.*  ------------------------ v
@@ -66,7 +78,7 @@ def setup_logging(
     """
     root_logger = logging.getLogger()
 
-    formatter = logging.Formatter(log_format, datefmt=log_datefmt)
+    formatter = _Formatter(log_format)
 
     handler = logging.FileHandler(log_file)
     handler.setFormatter(formatter)


### PR DESCRIPTION
to restore milisecond precision as before 9bd933e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized logging presentation change with no auth or data handling impact; only risk is downstream tools that assumed the previous timestamp string.
> 
> **Overview**
> Restores **millisecond precision** in default log timestamps (regression after a prior change) while keeping **timezone** in the rendered `%(asctime)s` field.
> 
> `setup_logging` now uses a private **`_Formatter`** that overrides `formatTime` to emit `YYYY-MM-DD HH:MM:SS,mmm TZ` instead of relying on stdlib `logging.Formatter` date formatting. The **`log_datefmt`** argument is removed from `setup_logging`; date/time layout is fixed inside `_Formatter`.
> 
> Tests were updated to assert on the formatter instance attached to handlers, and a new integration test checks the full default log line shape under UTC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6372f0cac81c3b283957b72fb67bd4bf6d94d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->