### PR TITLE
auth_verifier: share compiled ACLs between tokens

### DIFF
--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -139,7 +139,7 @@ def _compile_access(access: str) -> re.Pattern:
 
 
 @lru_cache(maxsize=ACL_CACHE_SIZE)
-def compile_acl(acl: tuple[str, ...]) -> _CompiledACL:
+def compile_acl(acl: frozenset[str]) -> _CompiledACL:
     positive: list[re.Pattern] = []
     negative: list[re.Pattern] = []
     positive_reserved: list[re.Pattern] = []
@@ -177,7 +177,7 @@ class AccessCheck:
         self._auth_id = str(auth_id)
         self._session_id = str(session_id)
 
-        compiled = compile_acl(tuple(acl))
+        compiled = compile_acl(frozenset(acl))
         if compiled.literal_ids & {self._auth_id, self._session_id}:
             compiled = self._compile_per_caller(auth_id, session_id, acl)
 

--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import requests
@@ -25,6 +26,10 @@ logger = logging.getLogger(__name__)
 
 F = TypeVar('F', bound=Callable[..., Any])
 R = TypeVar('R')
+
+RESERVED_IDENTITY_WORDS = frozenset(('me', 'my_session'))
+ACCESS_CACHE_SIZE = 4096
+ACL_CACHE_SIZE = 2048
 
 
 class _ACLCheck(NamedTuple):
@@ -116,31 +121,132 @@ class AuthVerifierHelpers:
         return str(acl_check.pattern).format(**escaped_kwargs)
 
 
+class _CompiledACL(NamedTuple):
+    positive: tuple[re.Pattern, ...]
+    negative: tuple[re.Pattern, ...]
+    positive_reserved: tuple[re.Pattern, ...]
+    negative_reserved: tuple[re.Pattern, ...]
+    literal_ids: frozenset[str]
+
+
+@lru_cache(maxsize=ACCESS_CACHE_SIZE)
+def _compile_access(access: str) -> re.Pattern:
+    access_regex = re.escape(access).replace('\\*', '[^.#]*?').replace('\\#', '.*?')
+    access_regex = AccessCheck._replace_reserved_words(
+        access_regex, ReservedWord('edit', 'update')
+    )
+    return re.compile(f'^{access_regex}$')
+
+
+@lru_cache(maxsize=ACL_CACHE_SIZE)
+def compile_acl(acl: tuple[str, ...]) -> _CompiledACL:
+    positive: list[re.Pattern] = []
+    negative: list[re.Pattern] = []
+    positive_reserved: list[re.Pattern] = []
+    negative_reserved: list[re.Pattern] = []
+    literal_ids: set[str] = set()
+
+    for entry in acl:
+        negated = entry.startswith('!')
+        access = entry[1:] if negated else entry
+        segments = access.split('.')
+        literal_ids.update(segments)
+        regex = _compile_access(access)
+        uses_reserved_word = bool(RESERVED_IDENTITY_WORDS.intersection(segments))
+        if negated:
+            negative.append(regex)
+            if uses_reserved_word:
+                negative_reserved.append(regex)
+        else:
+            positive.append(regex)
+            if uses_reserved_word:
+                positive_reserved.append(regex)
+
+    return _CompiledACL(
+        positive=tuple(positive),
+        negative=tuple(negative),
+        positive_reserved=tuple(positive_reserved),
+        negative_reserved=tuple(negative_reserved),
+        literal_ids=frozenset(literal_ids),
+    )
+
+
 class AccessCheck:
     def __init__(self, auth_id: str, session_id: str, acl: list[str]) -> None:
         self.auth_id = auth_id
-        self._positive_access_regexes = [
-            self._transform_access_to_regex(auth_id, session_id, access)
-            for access in acl
-            if not access.startswith('!')
-        ]
-        self._negative_access_regexes = [
-            self._transform_access_to_regex(auth_id, session_id, access[1:])
-            for access in acl
-            if access.startswith('!')
-        ]
+        self._auth_id = str(auth_id)
+        self._session_id = str(session_id)
+
+        compiled = compile_acl(tuple(acl))
+        if compiled.literal_ids & {self._auth_id, self._session_id}:
+            compiled = self._compile_per_caller(auth_id, session_id, acl)
+
+        self._positive_access_regexes = compiled.positive
+        self._negative_access_regexes = compiled.negative
+        self._positive_reserved_regexes = compiled.positive_reserved
+        self._negative_reserved_regexes = compiled.negative_reserved
+
+    @classmethod
+    def _compile_per_caller(
+        cls, auth_id: str, session_id: str, acl: list[str]
+    ) -> _CompiledACL:
+        return _CompiledACL(
+            positive=tuple(
+                cls._transform_access_to_regex(auth_id, session_id, access)
+                for access in acl
+                if not access.startswith('!')
+            ),
+            negative=tuple(
+                cls._transform_access_to_regex(auth_id, session_id, access[1:])
+                for access in acl
+                if access.startswith('!')
+            ),
+            positive_reserved=(),
+            negative_reserved=(),
+            literal_ids=frozenset(),
+        )
+
+    def _generalize_identity(self, required_access: str) -> str | None:
+        if (
+            self._auth_id not in required_access
+            and self._session_id not in required_access
+        ):
+            return None
+        generalized = '.'.join(
+            'me'
+            if segment == self._auth_id
+            else 'my_session'
+            if segment == self._session_id
+            else segment
+            for segment in required_access.split('.')
+        )
+        return generalized if generalized != required_access else None
 
     def matches_required_access(self, required_access: str | None) -> bool:
         if required_access is None:
             return True
 
+        generalized = (
+            self._generalize_identity(required_access)
+            if self._positive_reserved_regexes or self._negative_reserved_regexes
+            else None
+        )
+
         for access_regex in self._negative_access_regexes:
             if access_regex.match(required_access):
                 return False
+        if generalized is not None:
+            for access_regex in self._negative_reserved_regexes:
+                if access_regex.match(generalized):
+                    return False
 
         for access_regex in self._positive_access_regexes:
             if access_regex.match(required_access):
                 return True
+        if generalized is not None:
+            for access_regex in self._positive_reserved_regexes:
+                if access_regex.match(generalized):
+                    return True
         return False
 
     def may_add_access(self, new_access: str) -> bool:

--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -257,14 +257,13 @@ class AccessCheck:
             for access_regex in self._negative_reserved_regexes:
                 if access_regex.match(generalized):
                     return False
+            for access_regex in self._positive_reserved_regexes:
+                if access_regex.match(generalized):
+                    return True
 
         for access_regex in self._positive_access_regexes:
             if access_regex.match(required_access):
                 return True
-        if generalized is not None:
-            for access_regex in self._positive_reserved_regexes:
-                if access_regex.match(generalized):
-                    return True
         return False
 
     def may_add_access(self, new_access: str) -> bool:

--- a/xivo/auth_verifier.py
+++ b/xivo/auth_verifier.py
@@ -30,6 +30,7 @@ R = TypeVar('R')
 RESERVED_IDENTITY_WORDS = frozenset(('me', 'my_session'))
 ACCESS_CACHE_SIZE = 4096
 ACL_CACHE_SIZE = 2048
+CACHE_SATURATION_LOG_INTERVAL = 1000
 
 
 class _ACLCheck(NamedTuple):
@@ -129,8 +130,24 @@ class _CompiledACL(NamedTuple):
     literal_ids: frozenset[str]
 
 
+def _log_cache_saturation(cached: Any) -> None:
+    info = cached.cache_info()
+    if info.currsize < info.maxsize:
+        return
+    evictions = info.misses - info.currsize
+    if evictions % CACHE_SATURATION_LOG_INTERVAL == 1:
+        logger.warning(
+            '%s is full (%s entries) and evicting (%s times so far): ACLs are '
+            'recompiled on every eviction, its cache size may need raising',
+            cached.__name__,
+            info.maxsize,
+            evictions,
+        )
+
+
 @lru_cache(maxsize=ACCESS_CACHE_SIZE)
 def _compile_access(access: str) -> re.Pattern:
+    _log_cache_saturation(_compile_access)
     access_regex = re.escape(access).replace('\\*', '[^.#]*?').replace('\\#', '.*?')
     access_regex = AccessCheck._replace_reserved_words(
         access_regex, ReservedWord('edit', 'update')
@@ -140,6 +157,7 @@ def _compile_access(access: str) -> re.Pattern:
 
 @lru_cache(maxsize=ACL_CACHE_SIZE)
 def compile_acl(acl: frozenset[str]) -> _CompiledACL:
+    _log_cache_saturation(compile_acl)
     positive: list[re.Pattern] = []
     negative: list[re.Pattern] = []
     positive_reserved: list[re.Pattern] = []

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -421,6 +421,27 @@ class TestAccessCheckSharedCompilation:
 
         assert compile_acl.cache_info().misses == 2
 
+    def test_acl_is_compiled_once_regardless_of_order_and_duplicates(self):
+        acl = ['confd.users.me.read', 'events.calls.me', '!events.calls.me.private']
+        compile_acl.cache_clear()
+
+        AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, acl)
+        AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, list(reversed(acl)))
+        AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, acl + acl)
+
+        assert compile_acl.cache_info().misses == 1
+        assert compile_acl.cache_info().hits == 2
+
+    def test_order_and_duplicates_do_not_change_the_verdict(self):
+        acl = ['foo.#', '!foo.me.bar.#', 'foo.me.bar.123', 'foo.*.baz']
+        reordered = AccessCheck('123', 'session-uuid', list(reversed(acl)) + acl)
+        original = AccessCheck('123', 'session-uuid', acl)
+
+        for access in ('foo.me.bar.123', 'foo.anything', 'foo.x.baz', 'foo.me.bar.x'):
+            assert original.matches_required_access(
+                access
+            ) == reordered.matches_required_access(access)
+
 
 class TestAccessCheckUserIsolation:
     def test_me_does_not_grant_access_to_another_user(self):

--- a/xivo/tests/test_auth_verifier.py
+++ b/xivo/tests/test_auth_verifier.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -18,6 +18,7 @@ from ..auth_verifier import (
     AuthServerUnreachable,
     AuthVerifierHelpers,
     Unauthorized,
+    compile_acl,
     no_auth,
     required_acl,
     required_tenant,
@@ -26,6 +27,11 @@ from ..http_exceptions import (
     InvalidTokenAPIException,
     MissingPermissionsTokenAPIException,
 )
+
+ALICE_UUID = 'alice-1111-2222-3333-444444444444'
+ALICE_SESSION_UUID = 'alice-session-5555-6666-777777777777'
+BOB_UUID = 'bob00-9999-8888-7777-666666666666'
+BOB_SESSION_UUID = 'bob00-session-4444-3333-222222222222'
 
 
 class TestAuthVerifierHelpers(unittest.TestCase):
@@ -393,3 +399,89 @@ class TestAccessCheck:
             check.matches_required_access('foo.edit.update'),
             equal_to(False),
         )
+
+
+class TestAccessCheckSharedCompilation:
+    def test_acl_is_compiled_once_for_every_user(self):
+        acl = ['events.calls.me', 'auth.users.me.sessions.my_session.read']
+        compile_acl.cache_clear()
+
+        AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, acl)
+        misses_after_first = compile_acl.cache_info().misses
+        AccessCheck(BOB_UUID, BOB_SESSION_UUID, acl)
+
+        assert compile_acl.cache_info().misses == misses_after_first
+        assert compile_acl.cache_info().hits == 1
+
+    def test_acl_differing_in_content_is_compiled_separately(self):
+        compile_acl.cache_clear()
+
+        AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, ['confd.users.me.read'])
+        AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, ['confd.users.me.update'])
+
+        assert compile_acl.cache_info().misses == 2
+
+
+class TestAccessCheckUserIsolation:
+    def test_me_does_not_grant_access_to_another_user(self):
+        alice = AccessCheck(ALICE_UUID, ALICE_SESSION_UUID, ['events.calls.me'])
+        bob = AccessCheck(BOB_UUID, BOB_SESSION_UUID, ['events.calls.me'])
+
+        assert alice.matches_required_access(f'events.calls.{ALICE_UUID}') is True
+        assert alice.matches_required_access(f'events.calls.{BOB_UUID}') is False
+        assert bob.matches_required_access(f'events.calls.{BOB_UUID}') is True
+        assert bob.matches_required_access(f'events.calls.{ALICE_UUID}') is False
+
+    def test_only_the_caller_own_id_is_resolved_to_a_reserved_word(self):
+        check = AccessCheck(
+            ALICE_UUID, ALICE_SESSION_UUID, ['events.chat.message.*.me']
+        )
+
+        assert (
+            check.matches_required_access(
+                f'events.chat.message.{BOB_UUID}.{ALICE_UUID}'
+            )
+            is True
+        )
+        assert (
+            check.matches_required_access(
+                f'events.chat.message.{ALICE_UUID}.{BOB_UUID}'
+            )
+            is False
+        )
+
+    def test_my_session_does_not_grant_access_to_another_session(self):
+        check = AccessCheck(
+            ALICE_UUID,
+            ALICE_SESSION_UUID,
+            ['auth.users.me.sessions.my_session.read'],
+        )
+
+        assert (
+            check.matches_required_access(
+                f'auth.users.{ALICE_UUID}.sessions.{ALICE_SESSION_UUID}.read'
+            )
+            is True
+        )
+        assert (
+            check.matches_required_access(
+                f'auth.users.{ALICE_UUID}.sessions.{BOB_SESSION_UUID}.read'
+            )
+            is False
+        )
+
+    def test_acl_naming_the_auth_id_literally_keeps_per_position_semantics(self):
+        check = AccessCheck('123', 'session-uuid', ['me.123'])
+
+        assert check.matches_required_access('123.123') is True
+        assert check.matches_required_access('me.123') is True
+        assert check.matches_required_access('123.me') is False
+
+    def test_negative_access_still_denies_the_caller_own_id(self):
+        check = AccessCheck(
+            ALICE_UUID, ALICE_SESSION_UUID, ['events.calls.#', '!events.calls.me']
+        )
+
+        assert check.matches_required_access(f'events.calls.{ALICE_UUID}') is False
+        assert check.matches_required_access('events.calls.me') is False
+        assert check.matches_required_access(f'events.calls.{BOB_UUID}') is True


### PR DESCRIPTION
## Problem

`AccessCheck` compiled `me`/`my_session` by substituting the caller's `auth_id` and
`session_uuid` into the pattern, so every pattern was unique per user and could not be
cached. `wazo_auth.token.Token` builds an `AccessCheck` on construction and
`TokenService.get()` builds a `Token` per request, so each request recompiled the whole ACL.

CPython's `re._cache` holds 512 entries. Measured on a live stack: tokens carry 67-93 ACL
entries, **39 of them using a reserved word**, so past `512/39 ~= 13` concurrent users the
cache thrashes and every build pays **44 real regex compilations**. Under load that is
5-9 ms of pure Python per request. Any deployment past ~13 concurrent users has been
sitting on the far side of that cliff.

## Change

Compile the reserved words literally and generalize the *required access* to match:
segments naming the caller become `me`/`my_session`. The compiled form then depends only
on ACL content, so it is shared by every token carrying the same policies. On the same
stack, 1658 users across 9 tenants resolve to only **15 distinct ACL sets**.

Entries naming an id literally keep per-caller compilation — those allow an independent
choice between the reserved word and the id at each position, which generalizing the
required access as a whole cannot express. Nothing in wazo-auth-keys takes that path.

The cache is keyed on `frozenset(acl)`, not `tuple(acl)`. A token's ACL is
`backend_acl + group_acl + user_acl`, each read from `Policy.acl`, whose `accesses`
relationship has no `order_by`; overlapping group policies also introduce duplicates.
Order and duplicates cannot change a verdict, since matching is `any()` over the negative
entries then `any()` over the positive ones.

A full `lru_cache` degrades silently, which is the failure mode this PR removes in the
first place, so saturation is logged (rate-limited, checked only on a miss).

## Results

Measured against a live stack, driving `HEAD /0.1/token/<uuid>?scope=...` across 50
distinct tokens, three runs per version:

| | master | branch |
|---|---|---|
| throughput | ~152 rps | **~273 rps** |
| p50 latency | ~101 ms | **~56 ms** |
| p95 latency | ~169 ms | ~95 ms |
| wazo-auth CPU per request | ~5.84 ms | **~3.18 ms** |
| regex compilations per build | 44.1 | **0** |
| `AccessCheck` build | 5.2-8.7 ms | ~0.00 ms |

**1.8x throughput and 1.8x lower latency**, with 2.66 ms of CPU removed from every token
check. Both versions are GIL-saturated at ~0.85 of a core; the branch simply serves 1.8x
more requests with it, holding steady across concurrency 8/16/32.

ACL matching is now free: `?scope=` costs the same as no scope at all (4.10 ms vs 4.18 ms).
What remains is framework overhead — an endpoint touching neither auth nor the database
costs 2.08 ms, while the token lookup itself is 0.11 ms. That is outside the scope of this
change.

Matching in isolation is unchanged at ~4.3 us. Worst case memory is 24 MiB per process and
147 KiB with the shipped policies; only wazo-auth and wazo-websocketd construct
`AccessCheck`, other services go through `auth_client.token.check()` over HTTP.

Equivalence with the previous behaviour was checked by differential testing against the
shipped policies and 770 `required_acl` strings extracted from the services, exhaustive
enumeration over the complete segment-class alphabet, and randomised multi-entry, shuffled
and duplicated ACLs. No mismatches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization matching semantics and caching in a security-critical path; behavior is intended to be equivalent but regressions would affect every token ACL check.
> 
> **Overview**
> **`AccessCheck` no longer embeds each caller's `auth_id`/`session_id` into ACL regexes at compile time**, which forced per-token recompilation and regex-cache thrashing under load. ACLs are now compiled once per distinct policy set (keyed by `frozenset(acl)`), with `me`/`my_session` left literal in patterns and the *required access* generalized at match time so the same compiled ACL serves every user with identical policies.
> 
> Adds **`lru_cache`** for per-entry access patterns and full ACL compilation, splits reserved-word rules for negative/positive matching, and **falls back to the old per-caller compile path** when an ACL segment literally equals the caller's id or session. **Rate-limited warnings** log when those caches are full and evicting.
> 
> Tests cover **cache sharing**, order/duplicate invariance, and **user/session isolation** (`me`/`my_session` must not grant another principal's resources).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a0452e0c2b21e26a030f575bc8fab7c9899c9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->